### PR TITLE
Semver usually uses 3 numbers not 4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.1.{build}
+version: 1.0.{build}
 configuration: Release
 assembly_info:
   patch: true


### PR DESCRIPTION
In `appveyor.yml`
Necessary for making a second package version.
See http://semver.org/
