### PR TITLE
Remove unused refs

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -51,14 +51,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EndToEnd\ExceptionFingerprinting\ExceptionsAreFingerprinted.cs" />

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -40,13 +40,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
it looks like these framework assembly refs are unused, so lets remove them.
Kept `System.Xml` since it's in [the dependency for Newtonsoft.Json](https://www.nuget.org/packages/newtonsoft.json)
