### PR TITLE
Cope with a null in a LogEventInfo.Parameter

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperBadDataTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperBadDataTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using NLog.StructuredLogging.Json.Helpers;
+using NUnit.Framework;
+
+namespace NLog.StructuredLogging.Json.Tests.Helpers
+{
+    [TestFixture]
+    public class MapperBadDataTests
+    {
+        [Test]
+        public void CanCopeWithVariousParams()
+        {
+            var logEventInfo = new LogEventInfo
+            {
+                Exception = null,
+                Level = LogLevel.Error,
+                LoggerName = "ExampleLoggerName",
+                Message = "Example Message",
+                TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 6),
+                Parameters = new object[] { 123, 34.4d, "sometext", "" }
+            };
+
+            var dict = Mapper.ToDictionary(logEventInfo);
+
+            Assert.That(dict, Is.Not.Empty);
+        }
+        [Test]
+        public void CanCopeWithNullParams()
+        {
+            var logEventInfo = new LogEventInfo
+            {
+                Exception = null,
+                Level = LogLevel.Error,
+                LoggerName = "ExampleLoggerName",
+                Message = "Example Message",
+                TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 6),
+                Parameters = new object[] { "sometext", null }
+            };
+
+            var dict = Mapper.ToDictionary(logEventInfo);
+
+            Assert.That(dict, Is.Not.Empty);
+        }
+    }
+}

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="EndToEnd\ViaLayout\SimpleJsonInMessage.cs" />
     <Compile Include="EndToEnd\ViaLayout\UnfortunatelyComplexFlattenedJsonLayoutTests.cs" />
     <Compile Include="FakeTimeSource.cs" />
+    <Compile Include="Helpers\MapperBadDataTests.cs" />
     <Compile Include="LayoutRendererCallSiteTests.cs" />
     <Compile Include="LayoutRendererTests.cs" />
     <Compile Include="Helpers\MapperExceptionDataTests.cs" />

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -15,7 +15,7 @@ namespace NLog.StructuredLogging.Json.Helpers
                 {"TimeStamp", timestampUtcIso8601 },
                 {"Level", source.Level.ToString()},
                 {"LoggerName", source.LoggerName},
-                {"Message", source.FormattedMessage},
+                {"Message", source.FormattedMessage}
             };
 
             if (source.Exception != null)
@@ -29,7 +29,7 @@ namespace NLog.StructuredLogging.Json.Helpers
 
             if (source.Parameters != null)
             {
-                result.Add("Parameters", string.Join(",", source.Parameters.Select(x => x.ToString())));
+                result.Add("Parameters", string.Join(",", source.Parameters.Select(Convert.ValueAsString)));
             }
 
             if (source.StackTrace != null)


### PR DESCRIPTION
Replication of and fix for https://github.com/justeat/NLog.StructuredLogging.Json/issues/20
