### PR TITLE
DNM: Remove shouldly

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
@@ -65,7 +65,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         [Test]
         public virtual void ShouldHaveExpectedNumberOfLines()
         {
-            Assert.That(Result, Is.EqualTo(Iterations * 4));
+            Assert.That(Result.Count, Is.EqualTo(Iterations * 4));
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedAggregateExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.AggregateException: Aggregate Exception"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.AggregateException: Aggregate Exception"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("AggregateException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Aggregate Exception"));
             Assert.That(obj.GetValue("ExceptionStackTrace").ToString(), Does.Contain("   at NLog.StructuredLogging.Json.Tests.EndToEnd.AggregateExceptionEndToEndTests.PutStackTraceOnException"));
@@ -118,7 +118,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner1ExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 1"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.ApplicationException: Inner Exception 1"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 1"));
             ShouldHaveExpectedStacktrace(obj);
@@ -126,7 +126,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner2ExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 2"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.ApplicationException: Inner Exception 2"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 2"));
             ShouldHaveExpectedStacktrace(obj);
@@ -134,7 +134,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner3ExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 3"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.ApplicationException: Inner Exception 3"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 3"));
             ShouldHaveExpectedStacktrace(obj);
@@ -159,7 +159,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             foreach (var line in Result)
             {
-                Assert.That(line, Does.Contain(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.AggregateExceptionEndToEndTests\.When"));
+                Assert.That(line, Does.Contain(@"CallSite"":""NLog.StructuredLogging.Json.Tests.EndToEnd.AggregateExceptionEndToEndTests.When"));
             }
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using Shouldly;
 using System.Linq;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd
@@ -66,7 +65,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         [Test]
         public virtual void ShouldHaveExpectedNumberOfLines()
         {
-            Result.Count.ShouldBe(Iterations * 4);
+            Assert.That(Result, Is.EqualTo(Iterations * 4));
         }
 
         [Test]
@@ -74,7 +73,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch("Error");
+                Assert.That(line, Does.Contain("Error"));
             }
         }
 
@@ -111,46 +110,48 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedAggregateExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.AggregateException: Aggregate Exception");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("AggregateException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Aggregate Exception");
-            obj.GetValue("ExceptionStackTrace").ToString().ShouldMatch("   at NLog.StructuredLogging.Json.Tests.EndToEnd.AggregateExceptionEndToEndTests.PutStackTraceOnException");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.AggregateException: Aggregate Exception"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("AggregateException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Aggregate Exception"));
+            Assert.That(obj.GetValue("ExceptionStackTrace").ToString(), Does.Contain("   at NLog.StructuredLogging.Json.Tests.EndToEnd.AggregateExceptionEndToEndTests.PutStackTraceOnException"));
         }
 
         private void ShouldHaveLoggedInner1ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 1");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 1");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 1"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 1"));
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveLoggedInner2ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 2");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 2");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 2"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 2"));
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveLoggedInner3ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 3");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 3");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 3"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 3"));
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveExpectedStacktrace(JObject obj)
         {
-            obj.GetValue("ExceptionStackTrace").ToString().ShouldMatch("   at NLog.StructuredLogging.Json.Tests.EndToEnd.AggregateExceptionEndToEndTests.PutStackTraceOnException");
+            var trace = obj.GetValue("ExceptionStackTrace").ToString();
+            Assert.That(trace, Does.Contain("   at NLog.StructuredLogging.Json.Tests.EndToEnd.AggregateExceptionEndToEndTests.PutStackTraceOnException"));
         }
 
         private static void StringShouldStartWithOneOf(string value, params string[] targets)
         {
             var pass = targets.Any(t => value.StartsWith(t));
 
-            pass.ShouldBeTrue("Got " + value + ", expected one of" + string.Join(",", targets));
+            Assert.That(pass, Is.True,
+                "Got " + value + ", expected one of" + string.Join(",", targets));
         }
 
         [Test]
@@ -158,7 +159,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.AggregateExceptionEndToEndTests\.When");
+                Assert.That(line, Does.Contain(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.AggregateExceptionEndToEndTests\.When"));
             }
         }
 
@@ -169,8 +170,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
             {
                 if (line.Contains("InvalidOperationException"))
                 {
-                    line.ShouldMatch(@"""ex_key_1"":""ex_data_1");
-                    line.ShouldMatch(@"""ex_key_2"":""ex_data_2");
+                    Assert.That(line, Does.Contain(@"""ex_key_1"":""ex_data_1"));
+                    Assert.That(line, Does.Contain(@"""ex_key_2"":""ex_data_2"));
                 }
             }
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/DynamicLogPropertiesDoNotBleedToSubsequentLogEvents.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/DynamicLogPropertiesDoNotBleedToSubsequentLogEvents.cs
@@ -27,7 +27,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         [Test]
         public void Message2HasExpectedDynamicProperties()
         {
-            Assert.That(_m1["oddness"].Value<bool>(), Is.True);
+            Assert.That(_m2["oddness"].Value<bool>(), Is.True);
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/DynamicLogPropertiesDoNotBleedToSubsequentLogEvents.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/DynamicLogPropertiesDoNotBleedToSubsequentLogEvents.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 {
@@ -21,14 +20,14 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         [Test]
         public void Message1HasExpectedDynamicProperties()
         {
-            _m1["foo"].Value<string>().ShouldBe("bar");
-            _m1["baz"].Value<string>().ShouldBe("wibble");
+            Assert.That(_m1["foo"].Value<string>(), Is.EqualTo("bar"));
+            Assert.That(_m1["baz"].Value<string>(), Is.EqualTo("wibble"));
         }
 
         [Test]
         public void Message2HasExpectedDynamicProperties()
         {
-            _m2["oddness"].Value<bool>().ShouldBe(true);
+            Assert.That(_m1["oddness"].Value<bool>(), Is.True);
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ExceptionFingerprinting/ExceptionsAreFingerprinted.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ExceptionFingerprinting/ExceptionsAreFingerprinted.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using NLog.Layouts;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ExceptionFingerprinting
 {
@@ -50,8 +49,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ExceptionFingerprinting
         public void ShouldHaveFingerprint()
         {
             var value = Result["ExceptionFingerprint"].Value<string>();
-            value.ShouldNotBeNull();
-            value.Length.ShouldBeGreaterThan(0);
+            Assert.That(value, Is.Not.Null);
+            Assert.That(value, Is.Not.Empty);
         }
     }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ExceptionFingerprinting/NonExceptionsAreNotFingerprinted.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ExceptionFingerprinting/NonExceptionsAreNotFingerprinted.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using NLog.Layouts;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ExceptionFingerprinting
 {
@@ -22,7 +21,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ExceptionFingerprinting
         public void ShouldNotHaveFingerprint()
         {
             JToken val;
-            Result.TryGetValue("ExceptionFingerprint", StringComparison.InvariantCulture, out val).ShouldBeFalse();
+            var gotValue = Result.TryGetValue("ExceptionFingerprint", StringComparison.InvariantCulture, out val);
+            Assert.That(gotValue, Is.False);
         }
     }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/LeniencyOfAttributeNames/WhenReservedNamesAreUsedForAttributes.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/LeniencyOfAttributeNames/WhenReservedNamesAreUsedForAttributes.cs
@@ -33,13 +33,13 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.LeniencyOfAttributeNames
         [Test]
         public void TheDuplicateAttributeNameShouldBePresentWithDataPrefix()
         {
-            Assert.That(_result["data_TimeStamp"], Is.EqualTo(new DateTime(2016,01,01)));
+            Assert.That(_result["data_TimeStamp"].ToObject<DateTime>(), Is.EqualTo(new DateTime(2016,01,01)));
         }
 
         [Test]
         public void TheDuplicateAttributeNameShouldBePresentWithExceptionPrefix()
         {
-            Assert.That(_result["ex_TimeStamp"], Is.EqualTo(new DateTime(2016, 01, 02)));
+            Assert.That(_result["ex_TimeStamp"].ToObject<DateTime>(), Is.EqualTo(new DateTime(2016, 01, 02)));
         }
     }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/LeniencyOfAttributeNames/WhenReservedNamesAreUsedForAttributes.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/LeniencyOfAttributeNames/WhenReservedNamesAreUsedForAttributes.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using NLog.Layouts;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.LeniencyOfAttributeNames
 {
@@ -34,13 +33,13 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.LeniencyOfAttributeNames
         [Test]
         public void TheDuplicateAttributeNameShouldBePresentWithDataPrefix()
         {
-            _result["data_TimeStamp"].ShouldBe(new DateTime(2016,01,01));
+            Assert.That(_result["data_TimeStamp"], Is.EqualTo(new DateTime(2016,01,01)));
         }
 
         [Test]
         public void TheDuplicateAttributeNameShouldBePresentWithExceptionPrefix()
         {
-            _result["ex_TimeStamp"].ShouldBe(new DateTime(2016, 01, 02));
+            Assert.That(_result["ex_TimeStamp"], Is.EqualTo(new DateTime(2016, 01, 02)));
         }
     }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
@@ -101,7 +101,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedOuterExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.InvalidOperationException: Outer Exception"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.InvalidOperationException: Outer Exception"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("InvalidOperationException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Outer Exception"));
             ShouldHaveExpectedStacktrace(obj);
@@ -109,7 +109,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner1ExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ArgumentException: Inner Exception 1"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.ArgumentException: Inner Exception 1"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ArgumentException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 1"));
             ShouldHaveExpectedStacktrace(obj);
@@ -117,7 +117,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner2ExceptionCorrectly(JObject obj)
         {
-            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 2"));
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.ApplicationException: Inner Exception 2"));
             Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
             Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 2"));
             ShouldHaveExpectedStacktrace(obj);
@@ -140,7 +140,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             foreach (var line in Result)
             {
-                Assert.That(line, Does.Contain(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.NestedExceptionEndToEndTests\.When"));
+                Assert.That(line, Does.Contain(@"CallSite"":""NLog.StructuredLogging.Json.Tests.EndToEnd.NestedExceptionEndToEndTests.When"));
             }
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using Shouldly;
 using System.Linq;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd
@@ -61,7 +60,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         [Test]
         public virtual void ShouldHaveExpectedNumberOfLines()
         {
-            Result.Count.ShouldBe(Iterations * 3);
+            Assert.That(Result.Count, Is.EqualTo(Iterations * 3));
         }
 
         [Test]
@@ -69,7 +68,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch("Error");
+                Assert.That(line, Does.Contain("Error"));
             }
         }
 
@@ -102,37 +101,38 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedOuterExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.InvalidOperationException: Outer Exception");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("InvalidOperationException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Outer Exception");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.InvalidOperationException: Outer Exception"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("InvalidOperationException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Outer Exception"));
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveLoggedInner1ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ArgumentException: Inner Exception 1");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ArgumentException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 1");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ArgumentException: Inner Exception 1"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ArgumentException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 1"));
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveLoggedInner2ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 2");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
-            obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 2");
+            Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.ApplicationException: Inner Exception 2"));
+            Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("ApplicationException"));
+            Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Inner Exception 2"));
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveExpectedStacktrace(JObject obj)
         {
-            obj.GetValue("ExceptionStackTrace").ToString().ShouldMatch("   at NLog.StructuredLogging.Json.Tests.EndToEnd.NestedExceptionEndToEndTests.PutStackTraceOnException");
+            var trace = obj.GetValue("ExceptionStackTrace").ToString();
+            Assert.That(trace, Does.Contain("   at NLog.StructuredLogging.Json.Tests.EndToEnd.NestedExceptionEndToEndTests.PutStackTraceOnException"));
         }
         private static void StringShouldStartWithOneOf(string value, params string[] targets)
         {
             var pass = targets.Any(t => value.StartsWith(t));
 
-            pass.ShouldBeTrue("Got " + value + ", expected one of" + string.Join(",", targets));
+            Assert.That(pass, Is.True, "Got " + value + ", expected one of" + string.Join(",", targets));
         }
 
         [Test]
@@ -140,7 +140,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.NestedExceptionEndToEndTests\.When");
+                Assert.That(line, Does.Contain(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.NestedExceptionEndToEndTests\.When"));
             }
         }
 
@@ -151,8 +151,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
             {
                 if (line.Contains("InvalidOperationException"))
                 {
-                    line.ShouldMatch(@"""ex_key_1"":""ex_data_1");
-                    line.ShouldMatch(@"""ex_key_2"":""ex_data_2");
+                    Assert.That(line, Does.Contain(@"""ex_key_1"":""ex_data_1"));
+                    Assert.That(line, Does.Contain(@"""ex_key_2"":""ex_data_2"));
                 }
             }
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs
@@ -165,7 +165,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                Assert.That(line, Does.Contain(@"TimeStamp"":""\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2}\.\d{3,3}Z"));
+                Assert.That(line, Does.Match(@"TimeStamp"":""\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2}\.\d{3,3}Z"));
             }
         }
 
@@ -175,7 +175,7 @@ With lots of possibly bad things in it";
             foreach (var line in Result)
             {
                 var jo = JObject.Parse(line);
-                Assert.That(jo["TimeStamp"], Is.EqualTo(TimeSourceForTest.Time));
+                Assert.That(jo["TimeStamp"].ToObject<DateTime>(), Is.EqualTo(TimeSourceForTest.Time));
             }
         }
 
@@ -250,7 +250,7 @@ With lots of possibly bad things in it";
                     }
                     if (prop.Equals("Iteration"))
                     {
-                        Assert.That(actual[prop].Value<int>(), Is.GreaterThan(0));
+                        Assert.That(actual[prop].Value<int>(), Is.GreaterThanOrEqualTo(0));
                         continue;
                     }
 
@@ -293,9 +293,8 @@ With lots of possibly bad things in it";
                 var message = obj.GetValue("Message").ToString();
 
                 Assert.That(message, Does.Contain("This is a message"));
-                Assert.That(message, Does.Contain(@"!\""£\$%\^&\*"));
+                Assert.That(message, Does.Contain(@"!""£$%^&*"));
                 Assert.That(message, Does.Contain("With lots of possibly bad things in it"));
-                Assert.That(message, Does.Contain(@"This is a message\r\n!\"".*\$%\^&\*\r\n\r\nWith lots of possibly bad things in it"));
             }
         }
 
@@ -306,7 +305,7 @@ With lots of possibly bad things in it";
             {
                 Assert.That(line, Does.Contain(@"PropertyOne"":""one"""));
                 Assert.That(line, Does.Contain(@"PropertyTwo"":""2"""));
-                Assert.That(line, Does.Contain(@"Iteration"":""\d+"""));
+                Assert.That(line, Does.Match(@"Iteration"":""\d+"""));
             }
         }
 
@@ -316,7 +315,7 @@ With lots of possibly bad things in it";
             foreach (var line in Result)
             {
                 var obj = JObject.Parse(line);
-                Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.InvalidOperationException: Outer Exception"));
+                Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System.InvalidOperationException: Outer Exception"));
                 Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("InvalidOperationException"));
                 Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Outer Exception"));
                 Assert.That(obj.GetValue("ExceptionStackTrace").ToString(), Does.Contain("   at NLog.StructuredLogging.Json.Tests.EndToEnd.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.PutStackTraceOnException"));
@@ -328,7 +327,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                Assert.That(line, Does.Contain(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork\.When"));
+                Assert.That(line, Does.Contain(@"CallSite"":""NLog.StructuredLogging.Json.Tests.EndToEnd.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.When"));
             }
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs
@@ -7,7 +7,6 @@ using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 {
@@ -166,8 +165,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(
-                    @"TimeStamp"":""\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2}\.\d{3,3}Z");
+                Assert.That(line, Does.Contain(@"TimeStamp"":""\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:\d{2,2}\.\d{3,3}Z"));
             }
         }
 
@@ -177,14 +175,14 @@ With lots of possibly bad things in it";
             foreach (var line in Result)
             {
                 var jo = JObject.Parse(line);
-                jo["TimeStamp"].ShouldBe(TimeSourceForTest.Time);
+                Assert.That(jo["TimeStamp"], Is.EqualTo(TimeSourceForTest.Time));
             }
         }
 
         [Test]
         public virtual void ShouldHaveExpectedNumberOfLines()
         {
-            Result.Count.ShouldBe(Iterations);
+            Assert.That(Result.Count, Is.EqualTo(Iterations));
         }
 
         [Test]
@@ -192,7 +190,8 @@ With lots of possibly bad things in it";
         {
             var expected = GivenExpectedNumberBraces();
             var all = string.Concat(Result);
-            all.Count(c => c == '{').ShouldBe(expected);
+
+            Assert.That(all.Count(c => c == '{') , Is.EqualTo(expected));
         }
 
         [Test]
@@ -200,7 +199,8 @@ With lots of possibly bad things in it";
         {
             var expected = GivenExpectedNumberBraces();
             var all = string.Concat(Result);
-            all.Count(c => c == '}').ShouldBe(expected);
+
+            Assert.That(all.Count(c => c == '}'), Is.EqualTo(expected));
         }
 
         [Test]
@@ -208,7 +208,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.Last().ToString().ShouldBe("}");
+                Assert.That(line.Last().ToString(), Is.EqualTo("}"));
             }
         }
 
@@ -222,14 +222,14 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch("Error");
+                Assert.That(line, Does.Contain("Error"));
             }
         }
 
         [Test]
         public void EachPropertyShouldMatchControlOutput()
         {
-            _control.Count.ShouldBe(Iterations);
+            Assert.That(_control.Count, Is.EqualTo(Iterations));
 
             for (var i = 0; i < Iterations; i++)
             {
@@ -245,16 +245,16 @@ With lots of possibly bad things in it";
                     }
                     if (prop.Equals("ThreadId"))
                     {
-                        actual[prop].Value<int>().ShouldBeGreaterThan(0);
+                        Assert.That(actual[prop].Value<int>(), Is.GreaterThan(0));
                         continue;
                     }
                     if (prop.Equals("Iteration"))
                     {
-                        actual[prop].Value<int>().ShouldBeGreaterThanOrEqualTo(0);
+                        Assert.That(actual[prop].Value<int>(), Is.GreaterThan(0));
                         continue;
                     }
 
-                    actual[prop].ShouldBe(control[prop], () => AttributeMissingMessage(prop));
+                    Assert.That(actual[prop], Is.EqualTo(control[prop]), () => AttributeMissingMessage(prop));
                 }
             }
         }
@@ -271,7 +271,7 @@ With lots of possibly bad things in it";
         {
             foreach (var e in Result.Select(JToken.Parse))
             {
-                e.Count().ShouldBe(AttributesOnLogEvent.Count - _attributesNotYetAssertable.Count);
+                Assert.That(e.Count(), Is.EqualTo(AttributesOnLogEvent.Count - _attributesNotYetAssertable.Count));
             }
         }
 
@@ -280,7 +280,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(LoggerName);
+                Assert.That(line, Does.Contain(LoggerName));
             }
         }
 
@@ -291,10 +291,11 @@ With lots of possibly bad things in it";
             {
                 var obj = JObject.Parse(line);
                 var message = obj.GetValue("Message").ToString();
-                message.ShouldMatch("This is a message");
-                message.ShouldMatch(@"!\""£\$%\^&\*");
-                message.ShouldMatch("With lots of possibly bad things in it");
-                message.ShouldMatch(@"This is a message\r\n!\"".*\$%\^&\*\r\n\r\nWith lots of possibly bad things in it");
+
+                Assert.That(message, Does.Contain("This is a message"));
+                Assert.That(message, Does.Contain(@"!\""£\$%\^&\*"));
+                Assert.That(message, Does.Contain("With lots of possibly bad things in it"));
+                Assert.That(message, Does.Contain(@"This is a message\r\n!\"".*\$%\^&\*\r\n\r\nWith lots of possibly bad things in it"));
             }
         }
 
@@ -303,9 +304,9 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"PropertyOne"":""one""");
-                line.ShouldMatch(@"PropertyTwo"":""2""");
-                line.ShouldMatch(@"Iteration"":""\d+""");
+                Assert.That(line, Does.Contain(@"PropertyOne"":""one"""));
+                Assert.That(line, Does.Contain(@"PropertyTwo"":""2"""));
+                Assert.That(line, Does.Contain(@"Iteration"":""\d+"""));
             }
         }
 
@@ -315,10 +316,10 @@ With lots of possibly bad things in it";
             foreach (var line in Result)
             {
                 var obj = JObject.Parse(line);
-                obj.GetValue("Exception").ToString().ShouldMatch(@"System\.InvalidOperationException: Outer Exception");
-                obj.GetValue("ExceptionType").ToString().ShouldMatch("InvalidOperationException");
-                obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Outer Exception");
-                obj.GetValue("ExceptionStackTrace").ToString().ShouldMatch("   at NLog.StructuredLogging.Json.Tests.EndToEnd.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.PutStackTraceOnException");
+                Assert.That(obj.GetValue("Exception").ToString(), Does.Contain(@"System\.InvalidOperationException: Outer Exception"));
+                Assert.That(obj.GetValue("ExceptionType").ToString(), Does.Contain("InvalidOperationException"));
+                Assert.That(obj.GetValue("ExceptionMessage").ToString(), Does.Contain("Outer Exception"));
+                Assert.That(obj.GetValue("ExceptionStackTrace").ToString(), Does.Contain("   at NLog.StructuredLogging.Json.Tests.EndToEnd.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.PutStackTraceOnException"));
             }
         }
 
@@ -327,7 +328,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork\.When");
+                Assert.That(line, Does.Contain(@"CallSite"":""NLog\.StructuredLogging\.Json\.Tests\.EndToEnd\.UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork\.When"));
             }
         }
 
@@ -336,8 +337,8 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"""ex_key_1"":""ex_data_1");
-                line.ShouldMatch(@"""ex_key_2"":""ex_data_2");
+                Assert.That(line, Does.Contain(@"""ex_key_1"":""ex_data_1"));
+                Assert.That(line, Does.Contain(@"""ex_key_2"":""ex_data_2"));
             }
         }
 
@@ -346,7 +347,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"^\{");
+                Assert.That(line, Does.Match(@"^\{"));
             }
         }
 
@@ -355,7 +356,7 @@ With lots of possibly bad things in it";
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"\}$");
+                Assert.That(line, Does.Match(@"\}$"));
             }
         }
 
@@ -381,7 +382,7 @@ With lots of possibly bad things in it";
                 var chars = line.ToCharArray().ToArray();
                 foreach (var bc in controlCharacters)
                 {
-                    chars.ShouldNotContain(bc);
+                    Assert.That(chars.Any(ch => ch == bc), Is.False, "Contains bad char " + bc);
                 }
             }
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/FlattenedJsonTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/FlattenedJsonTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog.Layouts;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
 {
@@ -34,7 +33,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"""flat1"":""flat1""");
+                Assert.That(line, Does.Contain(@"""flat1"":""flat1"""));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
@@ -20,7 +20,9 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         {
             foreach (var line in Result)
             {
-                Assert.That(line, Is.EqualTo(@"\{\\""foo\\"":\\""bar\\"",\\""baz\\"":\{\\""wibble\\"":\\""chip\\""\}\}"));
+                Assert.That(line, Does.Contain(@"""json start {"));
+                Assert.That(line, Does.Contain(@"json end"""));
+                Assert.That(line, Does.Contain(@"{\""foo\"":\""bar\"",\""baz\"":{\""wibble\"":\""chip\""}}"));
             }
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
@@ -1,6 +1,5 @@
 using Newtonsoft.Json;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
 {
@@ -21,7 +20,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         {
             foreach (var line in Result)
             {
-                line.ShouldMatch(@"\{\\""foo\\"":\\""bar\\"",\\""baz\\"":\{\\""wibble\\"":\\""chip\\""\}\}");
+                Assert.That(line, Is.EqualTo(@"\{\\""foo\\"":\\""bar\\"",\\""baz\\"":\{\\""wibble\\"":\\""chip\\""\}\}"));
             }
         }
 
@@ -29,7 +28,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         public void ShouldBeSensibleNumberOfCharacters()
         {
             var all = string.Join("\n", Result);
-            all.Length.ShouldBeInRange(1350 * Iterations, 1550 * Iterations);
+
+            Assert.That(all.Length, Is.InRange(1350 * Iterations, 1550 * Iterations));
         }
 
         [Test]
@@ -37,7 +37,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         {
             foreach (var line in Result)
             {
-                line.Length.ShouldBeInRange(1350, 1550, "zzzzline start\n\n" +line + "\n\nzzzzzline end");
+                Assert.That(line.Length, Is.InRange(1350, 1550),
+                    "zzzzline start\n\n" +line + "\n\nzzzzzline end");
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/SimpleJsonInMessage.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/SimpleJsonInMessage.cs
@@ -5,7 +5,6 @@ using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
 {
@@ -79,7 +78,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         {
             foreach (var line in _output)
             {
-                line.Count(x => x == '{').ShouldBe(3, line);
+                Assert.That(line.Count(x => x == '{'), Is.EqualTo(3));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageContainsJson.cs
@@ -1,7 +1,6 @@
 using System;
 using Newtonsoft.Json;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayoutRenderer
 {
@@ -22,8 +21,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayoutRenderer
         {
             foreach (var line in Result)
             {
-                Console.WriteLine(line);
-                line.ShouldMatch(@"\{\\""foo\\"":\\""bar\\"",\\""baz\\"":\{\\""wibble\\"":\\""chip\\""\}\}");
+                //Console.WriteLine(line);
+                Assert.That(line, Does.Match(@"\{\\""foo\\"":\\""bar\\"",\\""baz\\"":\{\\""wibble\\"":\\""chip\\""\}\}"));
             }
         }
 
@@ -32,7 +31,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayoutRenderer
         {
             foreach (var line in Result)
             {
-                line.Length.ShouldBeInRange(550, 1450);
+                Assert.That(line.Length, Is.InRange(550, 1450));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/Hashing/HasherTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Hashing/HasherTests.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.Hashing
 {
@@ -12,7 +11,8 @@ namespace NLog.StructuredLogging.Json.Tests.Hashing
             var h = new HasherLayoutRenderer();
             h.Text = "{$date}";
             var output = h.Render(new LogEventInfo());
-            output.ShouldNotBeNull();
+
+            Assert.That(output, Is.Not.Null);
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
@@ -125,7 +125,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
                     throw inputEx;
                 }
 
-                //Console.WriteLine(message);
+                Console.WriteLine(message);
 
                 throw inputEx;
             }

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
@@ -115,7 +115,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
                 return ex;
             }
         }
-        
+
         private static Exception PutStackTraceOnExceptionGeneric<TObject>(Exception inputEx, bool secondLine, TObject message)
         {
             try
@@ -125,7 +125,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
                     throw inputEx;
                 }
 
-                Console.WriteLine(message);
+                //Console.WriteLine(message);
 
                 throw inputEx;
             }

--- a/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/JsonWithPropertiesLayoutTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/JsonWithPropertiesLayoutTests.cs
@@ -3,7 +3,6 @@ using NLog.Layouts;
 using NLog.Targets;
 using NLog.Time;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
 {
@@ -53,10 +52,10 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
             var logEvent = new LogEventInfo(LogLevel.Trace, LoggerName, TestMessage);
             logger.Log(logEvent);
 
-            target.Logs.Count.ShouldBe(1);
+            Assert.That(target.Logs.Count, Is.EqualTo(1));
 
             var output = target.Logs[0];
-            output.ShouldBe(expectedOutput);
+            Assert.That(output, Is.EqualTo(expectedOutput));
         }
 
         [Test]
@@ -90,10 +89,10 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
             var logEvent = new LogEventInfo(LogLevel.Trace, LoggerName, TestMessage);
             logger.Log(logEvent);
 
-            target.Logs.Count.ShouldBe(1);
+            Assert.That(target.Logs.Count, Is.EqualTo(1));
 
             var output = target.Logs[0];
-            output.ShouldBe(expectedOutput);
+            Assert.That(output, Is.EqualTo(expectedOutput));
         }
 
         [Test]
@@ -128,10 +127,10 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
             var logEvent = new LogEventInfo(LogLevel.Trace, LoggerName, TestMessage);
             logger.Log(logEvent);
 
-            target.Logs.Count.ShouldBe(1);
+            Assert.That(target.Logs.Count, Is.EqualTo(1));
 
             var output = target.Logs[0];
-            output.ShouldBe(expectedOutput);
+            Assert.That(output, Is.EqualTo(expectedOutput));
         }
 
         public class GetFormattedMessage
@@ -158,7 +157,7 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
                     "\",\"Message\":\"" + TestMessage +
                     "\",\"" + expectedPropertyName + "\":\"" + TestProperties.One + "\"}";
 
-                result.ShouldBe(expectedOutput, result);
+                Assert.That(result, Is.EqualTo(expectedOutput));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/StructuredLoggingPropertyTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/StructuredLoggingPropertyTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using NUnit.Framework;
-using Shouldly;
 
 namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
 {
@@ -14,15 +13,15 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
             [TestCase("  ")]
             public void DoesNotAllowEmptyName(object name)
             {
-                Action action = () => new StructuredLoggingProperty(name as string, "some-layout-value");
-                action.ShouldThrow<ArgumentException>();
+                Assert.Throws<ArgumentException>(
+                    () => new StructuredLoggingProperty(name as string, "some-layout-value"));
             }
 
             [Test]
             public void AllowsNullLayoutValues()
             {
-                Action action = () => new StructuredLoggingProperty("some-name", null);
-                action.ShouldThrow<ArgumentNullException>();
+                Assert.Throws<ArgumentNullException>(
+                    () => new StructuredLoggingProperty("some-name", null));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -46,10 +46,6 @@
       <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Shouldly.2.8.2\lib\net40\Shouldly.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/NLog.StructuredLogging.Json.Tests/packages.config
+++ b/src/NLog.StructuredLogging.Json.Tests/packages.config
@@ -4,5 +4,4 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NLog" version="4.4.3" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
-  <package id="Shouldly" version="2.8.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Some might like this PR, some might not.
Remove the use of `Shouldly` from the tests, as it doesn't add that much, and is another extra dependency that is easier to be without. 

Was a mixture of NUnit assert syntax and "should" extensions. Use NUnit syntax throughout.