### PR TITLE
Visual Studio 2017 csproj format

### DIFF
--- a/NLog.StructuredLogging.Json.Common.props
+++ b/NLog.StructuredLogging.Json.Common.props
@@ -11,11 +11,29 @@
     <PackageLicenseUrl>$(PackageProjectUrl)/blob/master/LICENSE</PackageLicenseUrl>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageTags>nlog;logging;json;kibana;structured-logging</PackageTags>
+    <PackageTags>nlog;logging;json;kibana;elk;structured-logging</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Major>1</Major>
+    <Minor>1</Minor>
+    <Revision>0</Revision>
+	
+    <BuildNumber Condition=" '$(APPVEYOR_BUILD_NUMBER)' != '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
+    <BuildNumber Condition=" '$(BUILD_NUMBER)' != '' ">$(BUILD_NUMBER)</BuildNumber>
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
+
+    <!-- Remove for release -->
+    <PrereleaseLabel>-beta</PrereleaseLabel>
+
+    <BuildSuffix Condition=" '$(PrereleaseLabel)' != '' ">$(PrereleaseLabel)-$(BuildNumber)</BuildSuffix>
+    <BuildSuffix Condition=" '$(BuildSuffix)' == '' "></BuildSuffix>
+
+    <AssemblyVersion>$(Major).0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>$(Major).$(Minor).$(Revision).$(BuildNumber)</AssemblyFileVersion>
+    <InformationalVersion>$(Major).$(Minor).$(Revision)$(BuildSuffix)</InformationalVersion>
+    <PackageVersion>$(Major).$(Minor).$(Revision)$(BuildSuffix)</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/NLog.StructuredLogging.Json.Common.props
+++ b/NLog.StructuredLogging.Json.Common.props
@@ -1,0 +1,21 @@
+﻿<Project>
+  <PropertyGroup>
+    <Authors>Just Eat</Authors>
+    <Company>Just Eat</Company>
+    <Copyright>Copyright (c) Just Eat 2015-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <PackageIconUrl>https://avatars3.githubusercontent.com/u/1516790?s=200</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/justeat/NLog.StructuredLogging.Json</PackageProjectUrl>
+    <PackageLicenseUrl>$(PackageProjectUrl)/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageTags>nlog;logging;json;kibana;structured-logging</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/NLog.StructuredLogging.Json.Common.props
+++ b/NLog.StructuredLogging.Json.Common.props
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/NLog.StructuredLogging.Json.sln
+++ b/NLog.StructuredLogging.Json.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.StructuredLogging.Json", "src\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj", "{E0357801-F86A-4F85-8246-1E06472C57B2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.StructuredLogging.Json", "src\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj", "{3BBCA830-F337-416F-8191-515B91774183}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.StructuredLogging.Json.Tests", "src\NLog.StructuredLogging.Json.Tests\NLog.StructuredLogging.Json.Tests.csproj", "{EE3EAA37-A6A8-45A3-9E15-31E42FF42959}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.StructuredLogging.Json.Tests", "src\NLog.StructuredLogging.Json.Tests\NLog.StructuredLogging.Json.Tests.csproj", "{72D9A869-3455-4DD1-863D-ABCB3C1B26BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E0357801-F86A-4F85-8246-1E06472C57B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E0357801-F86A-4F85-8246-1E06472C57B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E0357801-F86A-4F85-8246-1E06472C57B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E0357801-F86A-4F85-8246-1E06472C57B2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EE3EAA37-A6A8-45A3-9E15-31E42FF42959}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE3EAA37-A6A8-45A3-9E15-31E42FF42959}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE3EAA37-A6A8-45A3-9E15-31E42FF42959}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE3EAA37-A6A8-45A3-9E15-31E42FF42959}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BBCA830-F337-416F-8191-515B91774183}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BBCA830-F337-416F-8191-515B91774183}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BBCA830-F337-416F-8191-515B91774183}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BBCA830-F337-416F-8191-515B91774183}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72D9A869-3455-4DD1-863D-ABCB3C1B26BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72D9A869-3455-4DD1-863D-ABCB3C1B26BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72D9A869-3455-4DD1-863D-ABCB3C1B26BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72D9A869-3455-4DD1-863D-ABCB3C1B26BC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,25 @@
 os: Visual Studio 2017
-version: 1.0.{build}
+version: 1.1.{build}
 configuration: Release
-assembly_info:
-  patch: true
-  file: '**\*AssemblyInfo.*'
-  assembly_version: '{version}'
-  assembly_file_version: '{version}'
-  assembly_informational_version: '{version}'
+cache:
+  - packages
 before_build:
-- nuget restore
+  - nuget restore
+clone_depth: 1
 build:
   project: NLog.StructuredLogging.Json.sln
   parallel: true
-  publish_nuget: true
-  publish_nuget_symbols: true
-  include_nuget_references: true
   verbosity: normal
+pull_requests:
+  do_not_increment_build_number: true
 test_script:
   - ps: $wc = New-Object 'System.Net.WebClient'
   - .\src\NLog.StructuredLogging.Json.Tests\bin\Release\net462\NLog.StructuredLogging.Json.Tests.exe
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestResult.xml))
+after_build:
+- dotnet pack .\src\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj -o ../output --no-build
 artifacts:
-- path: 'NLog.StructuredLogging.Json.{version}*.nupkg'
+- path: 'output\*.nupkg'
 notifications:
 - provider: HipChat
   room: 'Eng :: Open Source'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,10 @@ build:
   verbosity: normal
 test_script:
   - ps: $wc = New-Object 'System.Net.WebClient'
+  - ps: write-host Starting tests
   - .\src\NLog.StructuredLogging.Json.Tests\bin\Release\net462\NLog.StructuredLogging.Json.Tests.exe
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestResult.xml))
+  - ps: write-host Done tests
 artifacts:
 - path: 'NLog.StructuredLogging.Json.{version}*.nupkg'
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,8 @@ build:
   verbosity: normal
 test_script:
   - ps: $wc = New-Object 'System.Net.WebClient'
-  - ps: write-host Starting tests
   - .\src\NLog.StructuredLogging.Json.Tests\bin\Release\net462\NLog.StructuredLogging.Json.Tests.exe
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestResult.xml))
-  - ps: write-host Done tests
 artifacts:
 - path: 'NLog.StructuredLogging.Json.{version}*.nupkg'
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ test_script:
   - .\src\NLog.StructuredLogging.Json.Tests\bin\Release\net462\NLog.StructuredLogging.Json.Tests.exe
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestResult.xml))
 after_build:
-- dotnet pack .\src\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj -o ../output --no-build
+- dotnet pack .\src\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj -o ../../output --no-build
 artifacts:
 - path: 'output\*.nupkg'
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+os: Visual Studio 2017
 version: 1.0.{build}
 configuration: Release
 assembly_info:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build:
   verbosity: normal
 test_script:
   - ps: $wc = New-Object 'System.Net.WebClient'
-  - .\src\NLog.StructuredLogging.Json.Tests\bin\Debug\net462\NLog.StructuredLogging.Json.Tests.exe
+  - .\src\NLog.StructuredLogging.Json.Tests\bin\Release\net462\NLog.StructuredLogging.Json.Tests.exe
   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestResult.xml))
 artifacts:
 - path: 'NLog.StructuredLogging.Json.{version}*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,10 @@ build:
   publish_nuget_symbols: true
   include_nuget_references: true
   verbosity: normal
-test:
-  assemblies: '**\*.Tests.dll'
+test_script:
+  - ps: $wc = New-Object 'System.Net.WebClient'
+  - .\src\NLog.StructuredLogging.Json.Tests\bin\Debug\net462\NLog.StructuredLogging.Json.Tests.exe
+  - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestResult.xml))
 artifacts:
 - path: 'NLog.StructuredLogging.Json.{version}*.nupkg'
 notifications:

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/DateTimePropertiesAreSerialised.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/DateTimePropertiesAreSerialised.cs
@@ -25,7 +25,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         [Test]
         public void OutputHasExpectedIso8601Dates()
         {
-            Assert.That(_output, Does.Contain("\"DateTimeInLocal\":\"2014-01-02T03:04:05.0000000+00:00\""));
+            Assert.That(_output, Does.Contain("\"DateTimeInLocal\":\"2014-01-02T03:04:05"));
             Assert.That(_output, Does.Contain("\"DateTimeInUtc\":\"2014-01-02T03:04:05.0000000Z\""));
             Assert.That(_output, Does.Contain("\"DateTimeOffsetInUtc\":\"2014-01-02T03:04:05.0000000Z\""));
             Assert.That(_output, Does.Contain("\"DateTimeOffsetWithOffset\":\"2014-01-02T03:04:05.0000000+04:00\""));

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/EndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/EndToEndTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
@@ -50,7 +50,11 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             ProgrammaticallyRegisterExtensions();
             var config = LogManager.Configuration;
+            Assert.That(config, Is.Not.Null, "No config");
+
             var target = GivenTarget(name);
+            Assert.That(target, Is.Not.Null, "No target");
+
             config.AddTarget(target);
             SetUpRules(target, config);
             ModifyLoggingConfigurationBeforeCommit(name, config);

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
@@ -30,7 +30,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
             var all = string.Join("\n", Result);
 
             Assert.That(all.Length,
-                Is.InRange(1350 * Iterations, 1550 * Iterations));
+                Is.InRange(1000 * Iterations, 1600 * Iterations));
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/MessageContainsJson.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
@@ -38,7 +38,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         {
             foreach (var line in Result)
             {
-                Assert.That(line.Length, Is.InRange(1350, 1550),
+                Assert.That(line.Length, Is.InRange(1000, 1600),
                     "zzzzline start\n\n" +line + "\n\nzzzzzline end");
             }
         }

--- a/src/NLog.StructuredLogging.Json.Tests/FakeTimeSource.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FakeTimeSource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NLog.Time;
 
 namespace NLog.StructuredLogging.Json.Tests
@@ -9,7 +9,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
         public FakeTimeSource()
         {
-            _fakeTime = new DateTime(2014,1,2,16,4,5, 623);
+            _fakeTime = new DateTime(2014,1,2,16,4,5, 623, DateTimeKind.Utc);
         }
 
         public override DateTime FromSystemTime(DateTime systemTime)

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
@@ -84,6 +84,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         }
 
         [Test]
+        [Ignore("Capturing line numbers in stack traces is dependant on debug settings")]
         public void IdenticalExceptionsFromDifferentLinesInAMethodHaveADifferentFingerprint()
         {
             Exception ex1 = PutStackTraceOnExceptionGeneric(new ApplicationException("test 1"), false, "Do stuff");

--- a/src/NLog.StructuredLogging.Json.Tests/LayoutRendererCallSiteTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LayoutRendererCallSiteTests.cs
@@ -24,7 +24,7 @@ namespace NLog.StructuredLogging.Json.Tests
                 Level = LogLevel.Error,
                 LoggerName = "ExampleLoggerName",
                 Message = "test message",
-                TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 623)
+                TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 623, DateTimeKind.Utc)
             };
 
             ThisNameWillAppearInTheCallSite(LogEvent);

--- a/src/NLog.StructuredLogging.Json.Tests/LayoutRendererTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LayoutRendererTests.cs
@@ -58,7 +58,7 @@ With lots of possibly bad things in it";
                 Message = Message,
                 Parameters = new object[] { "One", 1234 },
                 Properties = { { "PropertyOne", "one" }, { "PropertyTwo", 2 } },
-                TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 623)
+                TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 623, DateTimeKind.Utc)
             };
 
             Renderer = new StructuredLoggingLayoutRenderer();

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -22,4 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />
   </ItemGroup> 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -25,5 +25,10 @@
   </ItemGroup> 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup> 
+  <ItemGroup>
+    <None Update="nlog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -5,14 +5,10 @@
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup> 

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -7,7 +7,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -8,6 +8,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>True</DebugSymbols>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\NLog.StructuredLogging.Json.Common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <PackageId>NLog.StructuredLogging.Json.Tests</PackageId>

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -2,10 +2,7 @@
   <Import Project="..\..\NLog.StructuredLogging.Json.Common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <PackageId>NLog.StructuredLogging.Json.Tests</PackageId>
-    <RootNamespace>NLog.StructuredLogging.Json.Tests</RootNamespace>
     <TargetFrameworks>net462</TargetFrameworks>
-    <AssemblyName>NLog.StructuredLogging.Json.Tests</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -25,5 +22,5 @@
   </ItemGroup> 
   <ItemGroup>
     <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />
-  </ItemGroup>
+  </ItemGroup> 
 </Project>

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\NLog.StructuredLogging.Json.Common.props" />
   <PropertyGroup>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
 
@@ -18,6 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NLog" Version="4.4.4" />
     <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnitLite" Version="3.6.1" />
   </ItemGroup> 
   <ItemGroup>
     <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NLog" Version="5.0.0-beta06" />
+    <PackageReference Include="NLog" Version="4.4.4" />
     <PackageReference Include="NUnit" Version="3.6.1" />
   </ItemGroup> 
   <ItemGroup>

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -4,16 +4,14 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net462</TargetFrameworks>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
+  <PropertyGroup>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -1,140 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{EE3EAA37-A6A8-45A3-9E15-31E42FF42959}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <PackageId>NLog.StructuredLogging.Json.Tests</PackageId>
     <RootNamespace>NLog.StructuredLogging.Json.Tests</RootNamespace>
+    <TargetFrameworks>net462</TargetFrameworks>
     <AssemblyName>NLog.StructuredLogging.Json.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FakeItEasy.3.0.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.4.3\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-  </ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup> 
   <ItemGroup>
-    <Compile Include="EndToEnd\ExceptionFingerprinting\ExceptionsAreFingerprinted.cs" />
-    <Compile Include="EndToEnd\ExceptionFingerprinting\NonExceptionsAreNotFingerprinted.cs" />
-    <Compile Include="EndToEnd\LeniencyOfAttributeNames\WhenReservedNamesAreUsedForAttributes.cs" />
-    <Compile Include="EndToEnd\MultiThreadedUniqueKeysTests.cs" />
-    <Compile Include="EndToEnd\MultiThreadedUniqueValuesTests.cs" />
-    <Compile Include="EndToEnd\AggregateExceptionEndToEndTests.cs" />
-    <Compile Include="EndToEnd\NestedExceptionEndToEndTests.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\MultiThreadedUniqueKeysInLayoutRenderer.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\MultiThreadedUniqueValuesInLayoutRenderer.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\AggregateExceptionEndToEndTestsLayoutRenderer.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\NestedExceptionEndToEndTestsLayoutRenderer.cs" />
-    <Compile Include="EndToEnd\ViaLayout\MultiThreadedUniqueValuesInFlattenedJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\MultiUniqueKeysThreadedInFlattenedJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\AggregateExceptionEndToEndTestsInFlattenedJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\NestedExceptionEndToEndTestsInFlattenedJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\WithFailingLayout.cs" />
-    <Compile Include="FlattenedJsonCanSerializePushNotification.cs" />
-    <Compile Include="Hashing\HasherTests.cs" />
-    <Compile Include="Helpers\ConvertExceptionToFingerprintTests.cs" />
-    <Compile Include="Helpers\ConvertJsonTests.cs" />
-    <Compile Include="Helpers\ConvertValueAsStringTests.cs" />
-    <Compile Include="EndToEnd\DynamicLogPropertiesDoNotBleedToSubsequentLogEvents.cs" />
-    <Compile Include="EndToEnd\DateTimePropertiesAreSerialised.cs" />
-    <Compile Include="EndToEnd\EndToEndTests.cs" />
-    <Compile Include="EndToEnd\UnfortunatelyComplexEndToEndTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\DateTimePropertiesInLayoutRenderer.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\LayoutRendererDoesNotBleed.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\MessageContainsJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\AsyncFlattenedJsonTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs" />
-    <Compile Include="EndToEnd\ViaLayout\DateTimePropertiesInFlattenedJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\FlattenedJsonLayoutDoesNotBleed.cs" />
-    <Compile Include="EndToEnd\ViaLayout\FlattenedJsonTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\AsyncLayoutRendererTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs" />
-    <Compile Include="EndToEnd\ViaLayoutRenderer\LayoutRendererTestsThatTestSeveralFeaturesAtOnceToProveCombinationsWork.cs" />
-    <Compile Include="EndToEnd\MessageContainsNullParams.cs" />
-    <Compile Include="EndToEnd\ViaLayout\MessageContainsJson.cs" />
-    <Compile Include="EndToEnd\ViaLayout\SimpleJsonInMessage.cs" />
-    <Compile Include="EndToEnd\ViaLayout\UnfortunatelyComplexFlattenedJsonLayoutTests.cs" />
-    <Compile Include="FakeTimeSource.cs" />
-    <Compile Include="Helpers\MapperParametersTests.cs" />
-    <Compile Include="JsonWithProperties\FailingLayout.cs" />
-    <Compile Include="JsonWithProperties\JsonWithPropertiesLayoutTests.cs" />
-    <Compile Include="LayoutRendererCallSiteTests.cs" />
-    <Compile Include="LayoutRendererTests.cs" />
-    <Compile Include="Helpers\MapperExceptionDataTests.cs" />
-    <Compile Include="Helpers\MapperExceptionLoggingTests.cs" />
-    <Compile Include="Helpers\MapperDateTimeFormatTests.cs" />
-    <Compile Include="NestedExceptionTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Helpers\MapperStandardTests.cs" />
-    <Compile Include="SerializingJustSayingMessages.cs" />
-    <Compile Include="LoggerExtensionsTests.cs" />
-    <Compile Include="Helpers\ConvertToUtcIso8601Tests.cs" />
-    <Compile Include="JsonWithProperties\StructuredLoggingPropertyTests.cs" />
-    <Compile Include="ShouldAsserts.cs" />
-  </ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="3.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="NLog" Version="5.0.0-beta06" />
+    <PackageReference Include="NUnit" Version="3.6.1" />
+  </ItemGroup> 
   <ItemGroup>
-    <Content Include="nlog.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
-    </Content>
-    <None Include="NLog.xsd">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj">
-      <Project>{E0357801-F86A-4F85-8246-1E06472C57B2}</Project>
-      <Name>Nlog.Structuredlogging.Json</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/NLog.StructuredLogging.Json.Tests/Program.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Program.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using NUnitLite;
+
+namespace NLog.StructuredLogging.Json.Tests
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            return new AutoRun(typeof(Program).GetTypeInfo().Assembly).Execute(args);
+        }
+    }
+
+}

--- a/src/NLog.StructuredLogging.Json.Tests/Properties/AssemblyInfo.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]
-[assembly: Guid("b482187d-50ac-4c82-971c-e3ee284f5809")]

--- a/src/NLog.StructuredLogging.Json.Tests/Properties/AssemblyInfo.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Properties/AssemblyInfo.cs
@@ -1,35 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NLog.StructuredLogging.Json.Tests")]
-[assembly: AssemblyDescription("Tests on Structured logging as JSON with NLog")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("JUST EAT plc")]
-[assembly: AssemblyProduct("NLog.StructuredLogging.Json")]
-[assembly: AssemblyCopyright("Copyright © JUST EAT plc 2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("b482187d-50ac-4c82-971c-e3ee284f5809")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NLog.StructuredLogging.Json.Tests/packages.config
+++ b/src/NLog.StructuredLogging.Json.Tests/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="FakeItEasy" version="3.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NLog" version="4.4.3" targetFramework="net45" />
-  <package id="NUnit" version="3.6.1" targetFramework="net45" />
-</packages>

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -4,11 +4,10 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -4,11 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup>
-    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup> 

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -2,8 +2,6 @@
   <Import Project="..\..\NLog.StructuredLogging.Json.Common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <PackageId>NLog.StructuredLogging.Json</PackageId>
-    <RootNamespace>NLog.StructuredLogging.Json</RootNamespace>
     <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
 
@@ -19,5 +17,5 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NLog" Version="4.4.4" />
-  </ItemGroup>
+  </ItemGroup> 
 </Project>

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -7,7 +7,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -1,73 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{E0357801-F86A-4F85-8246-1E06472C57B2}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <PackageId>NLog.StructuredLogging.Json</PackageId>
     <RootNamespace>NLog.StructuredLogging.Json</RootNamespace>
-    <AssemblyName>NLog.StructuredLogging.Json</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.4.3\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup> 
   <ItemGroup>
-    <Compile Include="HasherLayoutRenderer.cs" />
-    <Compile Include="Helpers\Convert.cs" />
-    <Compile Include="FlattenedJsonLayout.cs" />
-    <Compile Include="Helpers\ConvertException.cs" />
-    <Compile Include="Helpers\ConvertJson.cs" />
-    <Compile Include="Helpers\Sha1Hasher.cs" />
-    <Compile Include="StructuredLoggingLayoutRenderer.cs" />
-    <Compile Include="LoggerExtensions.cs" />
-    <Compile Include="Helpers\Mapper.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Helpers\StackHelper.cs" />
-    <Compile Include="StructuredLoggingProperty.cs" />
-    <Compile Include="JsonWithPropertiesLayout.cs" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="NLog" Version="5.0.0-beta06" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\NLog.StructuredLogging.Json.Common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <PackageId>NLog.StructuredLogging.Json</PackageId>

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -17,6 +17,6 @@
   </ItemGroup> 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NLog" Version="5.0.0-beta06" />
+    <PackageReference Include="NLog" Version="4.4.4" />
   </ItemGroup>
 </Project>

--- a/src/NLog.StructuredLogging.Json/Properties/AssemblyInfo.cs
+++ b/src/NLog.StructuredLogging.Json/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]
-[assembly: Guid("9ca5ab06-26e6-48b2-a7f1-233bad75fd7e")]

--- a/src/NLog.StructuredLogging.Json/Properties/AssemblyInfo.cs
+++ b/src/NLog.StructuredLogging.Json/Properties/AssemblyInfo.cs
@@ -1,35 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NLog.StructuredLogging.Json")]
-[assembly: AssemblyDescription("Structured logging as JSON with NLog")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("JUST EAT plc")]
-[assembly: AssemblyProduct("NLog.StructuredLogging.Json")]
-[assembly: AssemblyCopyright("Copyright © JUST EAT plc 2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9ca5ab06-26e6-48b2-a7f1-233bad75fd7e")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NLog.StructuredLogging.Json/packages.config
+++ b/src/NLog.StructuredLogging.Json/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NLog" version="4.4.3" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Use the new VS2017 .csproj syntax. But not yet targeting .Net core. However do want to also target .Net core soon, so we want this new project format.

We have to use the Nunitlite runner. Tests are passing, locally and in appveyor.