### PR TITLE
Tests compile in .Net core

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <solution>
     <packageRestore>
-      <add key="enabled" value="True"/>
-      <add key="automatic" value="True"/>
+      <add key="enabled" value="True" />
+      <add key="automatic" value="True" />
     </packageRestore>
     <packageSources>
       <add key="NuGet official package source" value="https://nuget.org/api/v2/" />

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using NLog.StructuredLogging.Json.Tests;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 {
@@ -21,9 +22,9 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private static Exception GivenException()
         {
-            var inner1 = new ApplicationException("Inner Exception 1");
-            var inner2 = new ApplicationException("Inner Exception 2");
-            var inner3 = new ApplicationException("Inner Exception 3");
+            var inner1 = new LoggingException("Inner Exception 1");
+            var inner2 = new LoggingException("Inner Exception 2");
+            var inner3 = new LoggingException("Inner Exception 3");
 
             PutStackTraceOnException(inner1);
             PutStackTraceOnException(inner2);

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/AggregateExceptionEndToEndTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
-using NLog.StructuredLogging.Json.Tests;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 {
@@ -118,24 +117,24 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner1ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 1");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
+            obj.GetValue("Exception").ToString().ShouldMatch(@"LoggingException: Inner Exception 1");
+            obj.GetValue("ExceptionType").ToString().ShouldMatch("LoggingException");
             obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 1");
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveLoggedInner2ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 2");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
+            obj.GetValue("Exception").ToString().ShouldMatch(@"LoggingException: Inner Exception 2");
+            obj.GetValue("ExceptionType").ToString().ShouldMatch("LoggingException");
             obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 2");
             ShouldHaveExpectedStacktrace(obj);
         }
 
         private void ShouldHaveLoggedInner3ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 3");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
+            obj.GetValue("Exception").ToString().ShouldMatch(@"LoggingException: Inner Exception 3");
+            obj.GetValue("ExceptionType").ToString().ShouldMatch("LoggingException");
             obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 3");
             ShouldHaveExpectedStacktrace(obj);
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ExceptionFingerprinting/NonExceptionsAreNotFingerprinted.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ExceptionFingerprinting/NonExceptionsAreNotFingerprinted.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using NLog.Layouts;
@@ -21,7 +21,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ExceptionFingerprinting
         public void ShouldNotHaveFingerprint()
         {
             JToken val;
-            var gotValue = Result.TryGetValue("ExceptionFingerprint", StringComparison.InvariantCulture, out val);
+            var gotValue = Result.TryGetValue("ExceptionFingerprint", StringComparison.Ordinal, out val);
             Assert.That(gotValue, Is.False);
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
@@ -22,7 +22,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private static Exception GivenException()
         {
-            var inner2 = new ApplicationException("Inner Exception 2");
+            var inner2 = new LoggingException("Inner Exception 2");
             var inner1 = new ArgumentException("Inner Exception 1", inner2);
             var testEx = new InvalidOperationException("Outer Exception", inner1);
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
@@ -117,8 +117,8 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
         private void ShouldHaveLoggedInner2ExceptionCorrectly(JObject obj)
         {
-            obj.GetValue("Exception").ToString().ShouldMatch(@"System\.ApplicationException: Inner Exception 2");
-            obj.GetValue("ExceptionType").ToString().ShouldMatch("ApplicationException");
+            obj.GetValue("Exception").ToString().ShouldMatch(@"LoggingException: Inner Exception 2");
+            obj.GetValue("ExceptionType").ToString().ShouldMatch("LoggingException");
             obj.GetValue("ExceptionMessage").ToString().ShouldMatch("Inner Exception 2");
             ShouldHaveExpectedStacktrace(obj);
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
@@ -25,7 +25,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
             var output = LogManager.Configuration.LogMessage(loggerName).First();
 
             Assert.That(output, Does.StartWith(
-                "{\"fail1\":\"Render failed: ApplicationException Test render fail\",\"flat1\":\"flat1\",\"TimeStamp\":\""));
+                "{\"fail1\":\"Render failed: LoggingException Test render fail\",\"flat1\":\"flat1\",\"TimeStamp\":\""));
             Assert.That(output, Does.EndWith(
                 "\"prop1\":\"value1\",\"prop2\":\"2\"}"));
         }

--- a/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializePushNotification.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializePushNotification.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Reflection;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/ConvertExceptionToFingerprintTests.cs
@@ -20,7 +20,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void ExceptionFingerprintIsPresent()
         {
-            Exception ex = new ApplicationException("test 1");
+            Exception ex = new LoggingException("test 1");
 
             var fingerprint = ConvertException.ToFingerprint(ex);
 
@@ -30,8 +30,8 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void IdenticalMessageExceptionsHaveSameFingerprint()
         {
-            Exception ex1 = new ApplicationException("test 1");
-            Exception ex2 = new ApplicationException("test 1");
+            Exception ex1 = new LoggingException("test 1");
+            Exception ex2 = new LoggingException("test 1");
 
             var fingerprint1 = ConvertException.ToFingerprint(ex1);
             var fingerprint2 = ConvertException.ToFingerprint(ex2);
@@ -44,8 +44,8 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void DifferentMessageExceptionsHaveDifferentFingerprint()
         {
-            Exception ex1 = new ApplicationException("test 1");
-            Exception ex2 = new ApplicationException("test 2");
+            Exception ex1 = new LoggingException("test 1");
+            Exception ex2 = new LoggingException("test 2");
 
             var fingerprint1 = ConvertException.ToFingerprint(ex1);
             var fingerprint2 = ConvertException.ToFingerprint(ex2);
@@ -58,8 +58,8 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void StackTraceIsUsedWhenPresent()
         {
-            Exception ex1 = new ApplicationException("test 1");
-            Exception ex2 = PutStackTraceOnException(new ApplicationException("test 1"));
+            Exception ex1 = new LoggingException("test 1");
+            Exception ex2 = PutStackTraceOnException(new LoggingException("test 1"));
 
             var fingerprint1 = ConvertException.ToFingerprint(ex1);
             var fingerprint2 = ConvertException.ToFingerprint(ex2);
@@ -72,8 +72,8 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void IdenticalStacktraceExceptionsHaveSameFingerprint()
         {
-            Exception ex1 = PutStackTraceOnException(new ApplicationException("test 1"));
-            Exception ex2 = PutStackTraceOnException(new ApplicationException("test 1"));
+            Exception ex1 = PutStackTraceOnException(new LoggingException("test 1"));
+            Exception ex2 = PutStackTraceOnException(new LoggingException("test 1"));
 
             var fingerprint1 = ConvertException.ToFingerprint(ex1);
             var fingerprint2 = ConvertException.ToFingerprint(ex2);
@@ -87,8 +87,8 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Ignore("Capturing line numbers in stack traces is dependant on debug settings")]
         public void IdenticalExceptionsFromDifferentLinesInAMethodHaveADifferentFingerprint()
         {
-            Exception ex1 = PutStackTraceOnExceptionGeneric(new ApplicationException("test 1"), false, "Do stuff");
-            Exception ex2 = PutStackTraceOnExceptionGeneric(new ApplicationException("test 1"), true, "Do stuff");
+            Exception ex1 = PutStackTraceOnExceptionGeneric(new LoggingException("test 1"), false, "Do stuff");
+            Exception ex2 = PutStackTraceOnExceptionGeneric(new LoggingException("test 1"), true, "Do stuff");
 
             var fingerprint1 = ConvertException.ToFingerprint(ex1);
             var fingerprint2 = ConvertException.ToFingerprint(ex2);

--- a/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/FailingLayout.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/FailingLayout.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NLog.Layouts;
 
 namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
@@ -7,7 +7,7 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
     {
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
-            throw new ApplicationException("Test render fail");
+            throw new LoggingException("Test render fail");
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/JsonWithPropertiesLayoutTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/JsonWithProperties/JsonWithPropertiesLayoutTests.cs
@@ -83,7 +83,7 @@ namespace NLog.StructuredLogging.Json.Tests.JsonWithProperties
                 "\"Level\":\"Trace\"," +
                 "\"LoggerName\":\"" + LoggerName +
                 "\",\"Message\":\"" + TestMessage + "\"" +
-                ",\"One\":\"Render failed: ApplicationException Test render fail\"" +
+                ",\"One\":\"Render failed: LoggingException Test render fail\"" +
                 ",\"Two\":\"" + TestProperties.Two + "\"}";
 
             var logEvent = new LogEventInfo(LogLevel.Trace, LoggerName, TestMessage);

--- a/src/NLog.StructuredLogging.Json.Tests/LayoutRendererCallSiteTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LayoutRendererCallSiteTests.cs
@@ -42,7 +42,9 @@ namespace NLog.StructuredLogging.Json.Tests
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThisNameWillNotApppearinTheCallSite(LogEventInfo logEvt)
         {
+            #if NET462
             logEvt.SetStackTrace(new StackTrace(1), 0);
+            #endif
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/LoggingException.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggingException.cs
@@ -11,7 +11,6 @@ namespace NLog.StructuredLogging.Json.Tests
 
         public LoggingException(string message) : base(message)
         {
-            
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/LoggingException.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggingException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace NLog.StructuredLogging.Json.Tests
+{
+    [Serializable]
+    public class LoggingException : Exception
+    {
+        public LoggingException()
+        {
+        }
+
+        public LoggingException(string message) : base(message)
+        {
+            
+        }
+    }
+}

--- a/src/NLog.StructuredLogging.Json.Tests/LoggingException.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggingException.cs
@@ -2,7 +2,6 @@
 
 namespace NLog.StructuredLogging.Json.Tests
 {
-    [Serializable]
     public class LoggingException : Exception
     {
         public LoggingException()

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -2,22 +2,29 @@
   <Import Project="..\..\NLog.StructuredLogging.Json.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net462</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup> 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="NLog" Version="4.4.5" />
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnitLite" Version="3.6.1" />
+  </ItemGroup> 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="NLog" Version="5.0.0-beta06" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+  </ItemGroup> 
+   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="NLog" Version="4.4.5" />
   </ItemGroup> 
   <ItemGroup>
     <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />

--- a/src/NLog.StructuredLogging.Json.Tests/SerializingJustSayingMessages.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/SerializingJustSayingMessages.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
 
 namespace NLog.StructuredLogging.Json.Tests


### PR DESCRIPTION
Tests compile in .Net core (netstandard 1.6)
But are not yet run there.

Had to make a custom exception type "LoggingException" to replace ApplicationException
which will break some tests even in .Net regular.
NB not all test will work in .Net core, as some of them test the stack trace, which is currently unavailable until .NetStandard 2.0.