### PR TITLE
re-enable the test that's mysteriously failing in .Net core

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,5 +5,5 @@ export configuration=Release
 dotnet restore NLog.StructuredLogging.Json.sln --verbosity minimal || exit 1
 dotnet build src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj --output $artifacts --configuration $configuration --framework "netstandard1.3" || exit 1
 dotnet build src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj --output $artifacts --configuration $configuration --framework "netcoreapp1.0" || exit 1
-dotnet run --project src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj --configuration $configuration --framework "netcoreapp1.0" --where "cat != CallSite"  || exit 1
+dotnet run --project src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj --configuration $configuration --framework "netcoreapp1.0" --where "!(cat == CallSite || cat == NotInNetCore)"  || exit 1
 

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
@@ -57,7 +57,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
         }
 
         [Test]
-        [Ignore("todo: investigate why we don't get this failing prop out when in .Net core")]
+        [Category("NotInNetCore")]
         public void ShouldLogFailureWhenLayoutFails()
         {
             // arrange


### PR DESCRIPTION
but only for windows builds
Made a test category "NotInNetCore" for this.