### PR TITLE
Test various LogManager.ThrowExceptions states

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
@@ -16,6 +16,7 @@ namespace NLog.StructuredLogging.Json.Tests
         }
 
         [Test]
+        [Category("NotInNetCore")]
         public void ConfigurationTargetsIsPopulated()
         {
             var config = LoadConfig();
@@ -25,6 +26,7 @@ namespace NLog.StructuredLogging.Json.Tests
         }
 
         [Test]
+        [Category("NotInNetCore")]
         public void ConfigurationRulesIsPopulated()
         {
             var config = LoadConfig();

--- a/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+
+namespace NLog.StructuredLogging.Json.Tests
+{
+    [TestFixture]
+    public class ConfigFileTests
+    {
+        [Test]
+        public void ThrowExceptionsFlagShouldBeRead()
+        {
+            // throwExceptions="true" should have been read from nlog.config
+            Assert.That(LogManager.ThrowExceptions, Is.True);
+        }
+    }
+}

--- a/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using NLog.Config;
+using NUnit.Framework;
 
 namespace NLog.StructuredLogging.Json.Tests
 {
@@ -8,6 +9,8 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void ThrowExceptionsFlagShouldBeRead()
         {
+            LogManager.Configuration = new XmlLoggingConfiguration("nlog.config");
+
             // throwExceptions="true" should have been read from nlog.config
             Assert.That(LogManager.ThrowExceptions, Is.True);
         }

--- a/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace NLog.StructuredLogging.Json.Tests
 {
     [TestFixture]
+    [Category("NotInNetCore")]
     public class ConfigFileTests
     {
         [Test]
@@ -16,7 +17,6 @@ namespace NLog.StructuredLogging.Json.Tests
         }
 
         [Test]
-        [Category("NotInNetCore")]
         public void ConfigurationTargetsIsPopulated()
         {
             var config = LoadConfig();
@@ -26,7 +26,6 @@ namespace NLog.StructuredLogging.Json.Tests
         }
 
         [Test]
-        [Category("NotInNetCore")]
         public void ConfigurationRulesIsPopulated()
         {
             var config = LoadConfig();

--- a/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
@@ -9,10 +9,31 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void ThrowExceptionsFlagShouldBeRead()
         {
-            LogManager.Configuration = new XmlLoggingConfiguration("nlog.config");
-
             // throwExceptions="true" should have been read from nlog.config
             Assert.That(LogManager.ThrowExceptions, Is.True);
+        }
+
+        [Test]
+        public void ConfigurationTargetsIsPopulated()
+        {
+            var config = LoadConfig();
+
+            Assert.That(config.AllTargets, Is.Not.Null);
+            Assert.That(config.AllTargets, Is.Not.Empty);
+        }
+
+        [Test]
+        public void ConfigurationRulesIsPopulated()
+        {
+            var config = LoadConfig();
+
+            Assert.That(config.LoggingRules, Is.Not.Null);
+            Assert.That(config.LoggingRules, Is.Not.Empty);
+        }
+
+        private static LoggingConfiguration LoadConfig()
+        {
+            return new XmlLoggingConfiguration("nlog.config");
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/ConfigFileTests.cs
@@ -1,4 +1,6 @@
-﻿using NLog.Config;
+﻿using System;
+using System.IO;
+using NLog.Config;
 using NUnit.Framework;
 
 namespace NLog.StructuredLogging.Json.Tests
@@ -33,7 +35,17 @@ namespace NLog.StructuredLogging.Json.Tests
 
         private static LoggingConfiguration LoadConfig()
         {
-            return new XmlLoggingConfiguration("nlog.config");
+            var result = new XmlLoggingConfiguration(GetConfigPath());
+            Assert.That(result, Is.Not.Null);
+            return result;
+        }
+
+        private static string GetConfigPath()
+        {
+            var dir = AppContext.BaseDirectory;
+            var configPath = Path.Combine(dir, "nlog.config");
+            Assert.That(File.Exists(configPath), $"Can't find config file at path '{configPath}'");
+            return configPath;
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
@@ -155,18 +155,26 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
 
         private string FailingTargetOutput(string loggerName, bool layoutThrowsExceptions)
         {
-            // arrange
-            GivenLoggingIsConfiguredForTest(GivenFailingTarget(loggerName), layoutThrowsExceptions);
-            var logger = LogManager.GetLogger(loggerName);
+            var savedThrowState = LogManager.ThrowExceptions;
+            try
+            {
+                // arrange
+                GivenLoggingIsConfiguredForTest(GivenFailingTarget(loggerName), layoutThrowsExceptions);
+                var logger = LogManager.GetLogger(loggerName);
 
-            // act
-            logger.ExtendedInfo("test message", new { prop1 = "value1", prop2 = 2 });
+                // act
+                logger.ExtendedInfo("test message", new { prop1 = "value1", prop2 = 2 });
 
-            LogManager.Flush();
+                LogManager.Flush();
 
-            var output = LogManager.Configuration.LogMessage(loggerName).First();
-            Assert.That(output, Is.Not.Empty);
-            return output;
+                var output = LogManager.Configuration.LogMessage(loggerName).First();
+                Assert.That(output, Is.Not.Empty);
+                return output;
+            }
+            finally
+            {
+                LogManager.ThrowExceptions = savedThrowState;
+            }
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -11,6 +11,14 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="nlog.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="nlog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup> 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="3.1.0" />

--- a/src/NLog.StructuredLogging.Json.Tests/nlog.config
+++ b/src/NLog.StructuredLogging.Json.Tests/nlog.config
@@ -6,12 +6,12 @@
   <variable name="human_readable_layout" value="${longdate}|${level}|${logger}|${message}|${onexception:EXCEPTION OCCURRED\:${exception:format=type,message,method,stackTrace:maxInnerExceptionLevel=5:innerFormat=shortType,message,method,stackTrace}}"/>
   <targets async="true">
     <target xsi:type="Null" name="drop"/>
-    <target xsi:type="Debugger" name="Debugger" layout="${human_readable_layout}"/>
-    <target xsi:type="Console" name="Console" layout="${human_readable_layout}"/>
+    <target xsi:type="Debugger" name="debugger" layout="${human_readable_layout}"/>
+    <target xsi:type="Console" name="console" layout="${human_readable_layout}"/>
   </targets>
   <rules>
-    <logger name="*" minlevel="Trace" writeTo="Console"/>
-    <logger name="*" minlevel="Trace" writeTo="Debugger"/>
+    <logger name="*" minlevel="Trace" writeTo="console"/>
+    <logger name="*" minlevel="Trace" writeTo="debugger"/>
   </rules>
 </nlog>
 

--- a/src/NLog.StructuredLogging.Json.Tests/nlog.config
+++ b/src/NLog.StructuredLogging.Json.Tests/nlog.config
@@ -6,15 +6,12 @@
   <variable name="human_readable_layout" value="${longdate}|${level}|${logger}|${message}|${onexception:EXCEPTION OCCURRED\:${exception:format=type,message,method,stackTrace:maxInnerExceptionLevel=5:innerFormat=shortType,message,method,stackTrace}}"/>
   <targets async="true">
     <target xsi:type="Null" name="drop"/>
-    <target xsi:type="Debugger" name="debugger" layout="${human_readable_layout}"/>
-    <target
-      xsi:type="Console"
-      name="console"
-      layout="${human_readable_layout}"/>
+    <target xsi:type="Debugger" name="Debugger" layout="${human_readable_layout}"/>
+    <target xsi:type="Console" name="Console" layout="${human_readable_layout}"/>
   </targets>
   <rules>
-    <logger name="*" minlevel="Trace" writeTo="console"/>
-    <logger name="*" minlevel="Trace" writeTo="debugger"/>
+    <logger name="*" minlevel="Trace" writeTo="Console"/>
+    <logger name="*" minlevel="Trace" writeTo="Debugger"/>
   </rules>
 </nlog>
 

--- a/src/NLog.StructuredLogging.Json.Tests/nlog.config
+++ b/src/NLog.StructuredLogging.Json.Tests/nlog.config
@@ -3,22 +3,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       throwExceptions="true"
     autoReload="true">
-
-  <variable name="log_dir" value="${basedir}/../logs"/>
-  <variable name="archive_dir" value="${basedir}/../logs_archive"/>
   <variable name="human_readable_layout" value="${longdate}|${level}|${logger}|${message}|${onexception:EXCEPTION OCCURRED\:${exception:format=type,message,method,stackTrace:maxInnerExceptionLevel=5:innerFormat=shortType,message,method,stackTrace}}"/>
-
   <targets async="true">
     <target xsi:type="Null" name="drop"/>
-
     <target xsi:type="Debugger" name="debugger" layout="${human_readable_layout}"/>
-
     <target
       xsi:type="Console"
       name="console"
       layout="${human_readable_layout}"/>
   </targets>
-
   <rules>
     <logger name="*" minlevel="Trace" writeTo="console"/>
     <logger name="*" minlevel="Trace" writeTo="debugger"/>


### PR DESCRIPTION
More variations on LogManager.ThrowExceptions states
Fix to the failure discussed in https://github.com/NLog/NLog/issues/2057#issuecomment-293625641

There is still an issue where .Net core doesn't seem to be loading the `nlog.config` file.
Fortunately that is the domain of nlog itself, not NLog.StructuredLogging.Json