### PR TITLE
Correct invalid unquoted json in flattendedjsonlayout 

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NLog.Config;
+using NLog.Targets;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace NLog.StructuredLogging.Json.Tests
+{
+    [TestFixture]
+    public class FlattenedJsonCanSerializeToFile
+    {
+        [Test]
+        public void JsonOutputIsCorrect()
+        {
+            var fileName = UniqueLogFileName();
+
+            var fileLogger = GetFlattenedJsonFileLogger(fileName);
+            Assert.That(fileLogger, Is.Not.Null);
+
+            fileLogger.ExtendedInfo("This is a test", 
+                new
+                {
+                    Hello = "Hello",
+                    SomeText = "this is some, text. It has! punctation?",
+                    ANumber = 42,
+                    Sometime = new DateTime(2017, 4, 5, 6, 7, 8, DateTimeKind.Utc)                    
+                });
+
+            LogManager.Flush();
+            AssertIsJsonLogEntry(fileName);
+            ClearLoggingConfig();
+        }
+
+        private void AssertIsJsonLogEntry(string fileName)
+        {
+            var json = ParseFile(fileName);
+
+            // it should be json
+            Assert.That(json, Is.Not.Null);
+            Assert.That(json.HasValues);
+
+            // standard props should be present
+            Assert.That(json.GetValue("Message"), Is.Not.Null);
+            Assert.That(json.GetValue("TimeStamp"), Is.Not.Null);
+            Assert.That(json.GetValue("Level"), Is.Not.Null);
+
+            // custom props should be present
+            Assert.That(json.GetValue("Hello"), Is.Not.Null);
+            Assert.That(json.GetValue("SomeText"), Is.Not.Null);
+            Assert.That(json.GetValue("ANumber"), Is.Not.Null);
+            Assert.That(json.GetValue("Sometime"), Is.Not.Null);
+        }
+
+        private static JObject ParseFile(string fileName)
+        {
+            if (!File.Exists(fileName))
+            {
+                Assert.Fail($"no output file exists with name {fileName}");
+            }
+
+            var contents = File.ReadAllText(fileName);
+
+            if (string.IsNullOrWhiteSpace(contents))
+            {
+                Assert.Fail($"Output file {fileName} has no  contents");
+            }
+
+            var json = JObject.Parse(contents);
+            return json;
+        }
+
+        private static string UniqueLogFileName()
+        {
+            var unique = Guid.NewGuid().ToString();
+            var date = DateTime.UtcNow.ToString("yyyyMMdd_hhmmss");
+            return $"flattenedjson_{date}_{unique}.log";
+        }
+
+        private Logger GetFlattenedJsonFileLogger(string fileName)
+        {
+            var config = new LoggingConfiguration();
+
+            var target = new FileTarget
+            {
+                Name = $"test to file {fileName}",
+                FileName = fileName,
+                Layout = new FlattenedJsonLayout()
+            };
+
+            config.AddTarget(target);
+
+            var rule = new LoggingRule("*", LogLevel.Trace, target);
+            config.LoggingRules.Add(rule);
+
+            LogManager.Configuration = config;
+            return LogManager.GetCurrentClassLogger();
+        }
+
+        private void ClearLoggingConfig()
+        {
+            LogManager.Configuration = new LoggingConfiguration();
+        }
+    }
+}

--- a/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Reflection;
 using Newtonsoft.Json.Linq;
 using NLog.Config;
 using NLog.Targets;
@@ -14,7 +13,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void JsonOutputIsCorrect()
         {
-            var fileName = UniqueLogFileName();
+            var fileName = Path.GetTempFileName();
 
             var fileLogger = GetFlattenedJsonFileLogger(fileName);
             Assert.That(fileLogger, Is.Not.Null);
@@ -72,18 +71,6 @@ namespace NLog.StructuredLogging.Json.Tests
 
             // this will throw if the json is not valid
             return JObject.Parse(contents);
-        }
-
-        private static string UniqueLogFileName()
-        {
-            var unique = Guid.NewGuid().ToString("N");
-            var date = DateTime.UtcNow.ToString("yyyyMMdd_hhmmss");
-            var fileName = $"flattenedjson_{date}_{unique}.log";
-
-            var assemblyPath = Assembly.GetEntryAssembly().Location;
-            var path = Path.GetDirectoryName(assemblyPath);
-
-            return Path.Combine(path, fileName);
         }
 
         private Logger GetFlattenedJsonFileLogger(string fileName)

--- a/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.IO;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog.Config;
 using NLog.Targets;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace NLog.StructuredLogging.Json.Tests
 {

--- a/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using Newtonsoft.Json.Linq;
 using NLog.Config;
 using NLog.Targets;
@@ -75,9 +76,14 @@ namespace NLog.StructuredLogging.Json.Tests
 
         private static string UniqueLogFileName()
         {
-            var unique = Guid.NewGuid().ToString();
+            var unique = Guid.NewGuid().ToString("N");
             var date = DateTime.UtcNow.ToString("yyyyMMdd_hhmmss");
-            return $"flattenedjson_{date}_{unique}.log";
+            var fileName = $"flattenedjson_{date}_{unique}.log";
+
+            var assemblyPath = Assembly.GetEntryAssembly().Location;
+            var path = Path.GetDirectoryName(assemblyPath);
+
+            return Path.Combine(path, fileName);
         }
 
         private Logger GetFlattenedJsonFileLogger(string fileName)

--- a/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/FlattenedJsonCanSerializeToFile.cs
@@ -50,6 +50,9 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(json.GetValue("SomeText"), Is.Not.Null);
             Assert.That(json.GetValue("ANumber"), Is.Not.Null);
             Assert.That(json.GetValue("Sometime"), Is.Not.Null);
+
+            // but not true for any old string
+            Assert.That(json.GetValue("noSuchProp12345asdfg"), Is.Null);
         }
 
         private static JObject ParseFile(string fileName)
@@ -66,8 +69,8 @@ namespace NLog.StructuredLogging.Json.Tests
                 Assert.Fail($"Output file {fileName} has no  contents");
             }
 
-            var json = JObject.Parse(contents);
-            return json;
+            // this will throw if the json is not valid
+            return JObject.Parse(contents);
         }
 
         private static string UniqueLogFileName()

--- a/src/NLog.StructuredLogging.Json/FlattenedJsonLayout.cs
+++ b/src/NLog.StructuredLogging.Json/FlattenedJsonLayout.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using NLog.Config;
 using NLog.StructuredLogging.Json.Helpers;
 using NLog.LayoutRenderers.Wrappers;
@@ -33,6 +34,11 @@ namespace NLog.StructuredLogging.Json
             AppendExceptionData(logEvent, result);
 
             return ConvertJson.Serialize(result);
+        }
+
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            target.Append(GetFormattedMessage(logEvent) ?? string.Empty);
         }
 
         private void AppendDataFromAttributes(LogEventInfo logEvent, IDictionary<string, object> result)


### PR DESCRIPTION
Correct invalid unquoted json in `flattendedjsonlayout` when writing to file. It is this issue and related things: https://github.com/justeat/NLog.StructuredLogging.Json/issues/54

The issue does not occur with in-memory tests, only with file output.  We have lots of in-memory tests :(

How to replicate the issue: Add the following to `NLog.StructuredLogging.Json\src\NLog.StructuredLogging.Json.Tests\nlog.config` 
under `<targets>`:
```xml
<target name="jsonout" fileName="jsonout.log" xsi:type="File" encoding="utf-8" concurrentWrites="false" keepFileOpen="false">
    <layout xsi:Type="flattenedjsonlayout">
    </layout>
</target>  
```

Under `<rules>`:
```xml
<logger name="*" minlevel="Trace" writeTo="jsonout"/>`
```

BUild and run the test suite. Inspect the file `jsonout.log` in the test folder. It contains entries like
`{"TimeStamp":2014-01-02T16:04:05.623Z,"Level":Error,"LoggerName":ExampleLogger,"Message":boom!`

Note that no values are quoted. 

Apply the override to `FlattenedJsonLayout.RenderFormattedMessage` and delete the file `jsonout.log`. Build and run the test suite.

This message  in `jsonout.log` is now `{"TimeStamp":"2014-01-02T16:04:05.623Z","Level":"Error","LoggerName":"ExampleLogger","Message":"boom!"`

What was happening is that the `RenderFormattedMessage` overload from the base class `JsonLayout` was being applied to append to a file, when it's not correct. Code like that in the ancestor class `Layout` should be applied instead.

Success!
