### PR TITLE
NUnit test refactor

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperExceptionLoggingTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperExceptionLoggingTests.cs
@@ -17,7 +17,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
             logEventInfo.Exception = null;
             var result = Mapper.ToDictionary(logEventInfo);
 
-            Assert.AreEqual(7, result.Count);
+            Assert.That(result.Count, Is.EqualTo(7));
         }
 
         [Test]
@@ -29,7 +29,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
 
             var result = Mapper.ToDictionary(logEventInfo);
 
-            Assert.AreEqual(10, result.Count);
+            Assert.That(result.Count, Is.EqualTo(10));
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperStandardTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperStandardTests.cs
@@ -21,7 +21,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void WhenConverted_TheRightNumberOfItemsAreReturned()
         {
-            Assert.AreEqual(12, _result.Count);
+            Assert.That(_result.Count, Is.EqualTo(12));
         }
 
         [Test]
@@ -51,8 +51,8 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
             Assert.True(_result.Keys.Contains("PropertyOne"));
             Assert.True(_result.Keys.Contains("PropertyTwo"));
 
-            Assert.AreEqual("This value is in property one", _result["PropertyOne"]);
-            Assert.AreEqual("2", _result["PropertyTwo"]);
+            Assert.That(_result["PropertyOne"], Is.EqualTo("This value is in property one"));
+            Assert.That(_result["PropertyTwo"], Is.EqualTo("2"));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         {
             string expected = $"System.Exception: Outer Exception ---> System.Exception: Inner Exception{Environment.NewLine}   --- End of inner exception stack trace ---";
 
-            Assert.AreEqual(expected, _result["Exception"]);
+            Assert.That(_result["Exception"], Is.EqualTo(expected));
         }
 
         private LogEventInfo MakeStandardLogEventInfo()

--- a/src/NLog.StructuredLogging.Json.Tests/LayoutRendererTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LayoutRendererTests.cs
@@ -107,25 +107,25 @@ With lots of possibly bad things in it";
         {
             var chars = Result.ToCharArray().ToArray();
 
-            Assert.IsFalse(chars.Contains('\u0001'));
-            Assert.IsFalse(chars.Contains('\u0002'));
-            Assert.IsFalse(chars.Contains('\u0003'));
-            Assert.IsFalse(chars.Contains('\u0004'));
-            Assert.IsFalse(chars.Contains('\u0005'));
-            Assert.IsFalse(chars.Contains('\u0006'));
-            Assert.IsFalse(chars.Contains('\u0007'));
-            Assert.IsFalse(chars.Contains('\u0008'));
-            Assert.IsFalse(chars.Contains('\u0009'));
-            Assert.IsFalse(chars.Contains('\u0010'));
-            Assert.IsFalse(chars.Contains('\u0011'));
-            Assert.IsFalse(chars.Contains('\u0012'));
-            Assert.IsFalse(chars.Contains('\u0013'));
-            Assert.IsFalse(chars.Contains('\u0014'));
-            Assert.IsFalse(chars.Contains('\u0015'));
-            Assert.IsFalse(chars.Contains('\u0016'));
-            Assert.IsFalse(chars.Contains('\u0017'));
-            Assert.IsFalse(chars.Contains('\u0018'));
-            Assert.IsFalse(chars.Contains('\u0019'));
+            Assert.That(chars.Contains('\u0001'), Is.False);
+            Assert.That(chars.Contains('\u0002'), Is.False);
+            Assert.That(chars.Contains('\u0003'), Is.False);
+            Assert.That(chars.Contains('\u0004'), Is.False);
+            Assert.That(chars.Contains('\u0005'), Is.False);
+            Assert.That(chars.Contains('\u0006'), Is.False);
+            Assert.That(chars.Contains('\u0007'), Is.False);
+            Assert.That(chars.Contains('\u0008'), Is.False);
+            Assert.That(chars.Contains('\u0009'), Is.False);
+            Assert.That(chars.Contains('\u0010'), Is.False);
+            Assert.That(chars.Contains('\u0011'), Is.False);
+            Assert.That(chars.Contains('\u0012'), Is.False);
+            Assert.That(chars.Contains('\u0013'), Is.False);
+            Assert.That(chars.Contains('\u0014'), Is.False);
+            Assert.That(chars.Contains('\u0015'), Is.False);
+            Assert.That(chars.Contains('\u0016'), Is.False);
+            Assert.That(chars.Contains('\u0017'), Is.False);
+            Assert.That(chars.Contains('\u0018'), Is.False);
+            Assert.That(chars.Contains('\u0019'), Is.False);
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
@@ -41,7 +41,7 @@ namespace NLog.StructuredLogging.Json.Tests
             var props = new { Key1 = "Value One" };
             _logger.ExtendedInfo("hello world", props);
 
-            var eventInfo = _events.First();
+            var eventInfo = _events.Single();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
@@ -64,7 +64,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             MethodThatDoesSomeLogging();
 
-            var eventInfo = _events.First();
+            var eventInfo = _events.Single();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
@@ -87,7 +87,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             await MethodThatDoesSomeLoggingAsync();
 
-            var eventInfo = _events.First();
+            var eventInfo = _events.Single();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
@@ -110,7 +110,7 @@ namespace NLog.StructuredLogging.Json.Tests
             var props = new { Key1 = "Value One" };
             _logger.ExtendedInfo("hello world", props);
 
-            var eventInfo = _events.First();
+            var eventInfo = _events.Single();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
@@ -43,7 +43,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var eventInfo = _events.First();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsNotEmpty(eventInfo.Properties);
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
@@ -66,7 +66,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var eventInfo = _events.First();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsNotEmpty(eventInfo.Properties);
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
@@ -89,7 +89,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var eventInfo = _events.First();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsNotEmpty(eventInfo.Properties);
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
@@ -112,7 +112,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var eventInfo = _events.First();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsNotEmpty(eventInfo.Properties);
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
@@ -142,7 +142,7 @@ namespace NLog.StructuredLogging.Json.Tests
             {
                 Assert.That(logEventInfo.Level, Is.EqualTo(LogLevel.Info));
                 Assert.That(logEventInfo.Message, Does.StartWith("Info in task"));
-                Assert.IsNotEmpty(logEventInfo.Properties);
+                Assert.That(logEventInfo.Properties, Is.Not.Empty);
                 Assert.That(logEventInfo.Properties.Count(x => x.Key.Equals("parallelContext")), Is.EqualTo(1));
                 Assert.That(logEventInfo.Properties["parallelContext"], Is.EqualTo("From MDLC"));
             }

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
@@ -42,16 +42,16 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedInfo("hello world", props);
 
             var eventInfo = _events.First();
-            Assert.AreEqual(LogLevel.Info, eventInfo.Level);
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsNotEmpty(eventInfo.Properties);
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", eventInfo.Properties["Key1"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("a2")));
-            Assert.AreEqual("Value Two", eventInfo.Properties["a2"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("a2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["a2"], Is.EqualTo("Value Two"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("a3")));
-            Assert.AreEqual("34", eventInfo.Properties["a3"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("a3")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["a3"], Is.EqualTo("34"));
 
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -65,16 +65,16 @@ namespace NLog.StructuredLogging.Json.Tests
             MethodThatDoesSomeLogging();
 
             var eventInfo = _events.First();
-            Assert.AreEqual(LogLevel.Info, eventInfo.Level);
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsNotEmpty(eventInfo.Properties);
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", eventInfo.Properties["Key1"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("b2")));
-            Assert.AreEqual("Value Two", eventInfo.Properties["b2"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("b2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["b2"], Is.EqualTo("Value Two"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("b3")));
-            Assert.AreEqual("34", eventInfo.Properties["b3"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("b3")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["b3"], Is.EqualTo("34"));
 
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -88,16 +88,16 @@ namespace NLog.StructuredLogging.Json.Tests
             await MethodThatDoesSomeLoggingAsync();
 
             var eventInfo = _events.First();
-            Assert.AreEqual(LogLevel.Info, eventInfo.Level);
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsNotEmpty(eventInfo.Properties);
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", eventInfo.Properties["Key1"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("c2")));
-            Assert.AreEqual("Value Two", eventInfo.Properties["c2"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("c2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["c2"], Is.EqualTo("Value Two"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("c3")));
-            Assert.AreEqual("34", eventInfo.Properties["c3"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("c3")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["c3"], Is.EqualTo("34"));
 
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -111,13 +111,13 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedInfo("hello world", props);
 
             var eventInfo = _events.First();
-            Assert.AreEqual(LogLevel.Info, eventInfo.Level);
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsNotEmpty(eventInfo.Properties);
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", eventInfo.Properties["Key1"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
 
-            Assert.AreEqual(1, eventInfo.Properties.Count(x => x.Key.Equals("log_context_Key1")));
-            Assert.AreEqual("Value MDLC", eventInfo.Properties["log_context_Key1"]);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("log_context_Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["log_context_Key1"], Is.EqualTo("Value MDLC"));
 
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -140,11 +140,11 @@ namespace NLog.StructuredLogging.Json.Tests
 
             foreach (var logEventInfo in _events)
             {
-                Assert.AreEqual(LogLevel.Info, logEventInfo.Level);
+                Assert.That(logEventInfo.Level, Is.EqualTo(LogLevel.Info));
                 Assert.That(logEventInfo.Message, Does.StartWith("Info in task"));
                 Assert.IsNotEmpty(logEventInfo.Properties);
-                Assert.AreEqual(1, logEventInfo.Properties.Count(x => x.Key.Equals("parallelContext")));
-                Assert.AreEqual("From MDLC", logEventInfo.Properties["parallelContext"]);
+                Assert.That(logEventInfo.Properties.Count(x => x.Key.Equals("parallelContext")), Is.EqualTo(1));
+                Assert.That(logEventInfo.Properties["parallelContext"], Is.EqualTo("From MDLC"));
             }
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
@@ -225,7 +225,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(parameters.Properties.Count, Is.EqualTo(2));
             Assert.That(parameters.Properties["ExceptionIndex"], Is.EqualTo(1));
             Assert.That(parameters.Properties["ExceptionCount"], Is.EqualTo(1));
-            Assert.IsFalse(parameters.Properties.ContainsKey("ExceptionTag"));
+            Assert.That(parameters.Properties.ContainsKey("ExceptionTag"), Is.False);
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.IsNotEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Not.Empty);
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
@@ -75,7 +75,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsNotEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Not.Empty);
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
@@ -96,7 +96,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsNotEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Not.Empty);
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
@@ -156,7 +156,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.IsNotEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Not.Empty);
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
@@ -232,7 +232,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.IsNotEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Not.Empty);
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
@@ -256,7 +256,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.IsNotEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Not.Empty);
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
             Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedDebug("hello world", null);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Debug, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Debug));
             Assert.IsEmpty(parameters.Properties);
         }
 
@@ -37,12 +37,12 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedDebug("hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Debug, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Debug));
             Assert.IsNotEmpty(parameters.Properties);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", parameters.Properties["Key1"]);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("key2")));
-            Assert.AreEqual("Value Two", parameters.Properties["key2"]);
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -64,7 +64,7 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedInfo("hello world", null);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Info, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsEmpty(parameters.Properties);
         }
 
@@ -74,12 +74,12 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedInfo("hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Info, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsNotEmpty(parameters.Properties);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", parameters.Properties["Key1"]);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("key2")));
-            Assert.AreEqual("Value Two", parameters.Properties["key2"]);
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -95,12 +95,12 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedInfo("hello world", props);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Info, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
             Assert.IsNotEmpty(parameters.Properties);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", parameters.Properties["Key1"]);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("key2")));
-            Assert.AreEqual("Value Two", parameters.Properties["key2"]);
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -122,7 +122,7 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedWarn("hello world", null);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Warn, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Warn));
             Assert.IsEmpty(parameters.Properties);
         }
 
@@ -144,7 +144,7 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedError("hello world", null);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.IsEmpty(parameters.Properties);
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
@@ -155,12 +155,12 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedError("hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.IsNotEmpty(parameters.Properties);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", parameters.Properties["Key1"]);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("key2")));
-            Assert.AreEqual("Value Two", parameters.Properties["key2"]);
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -182,9 +182,9 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedException(new Exception("example exception"), "hello world", new {});
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.NotNull(parameters.Exception);
-            Assert.AreEqual("example exception", parameters.Exception.Message);
+            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -194,9 +194,9 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedException(new Exception("example exception"), "hello world", null);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.NotNull(parameters.Exception);
-            Assert.AreEqual("example exception", parameters.Exception.Message);
+            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -206,9 +206,9 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedException(new Exception("example exception"), "hello world");
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.NotNull(parameters.Exception);
-            Assert.AreEqual("example exception", parameters.Exception.Message);
+            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -219,9 +219,9 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
 
-            Assert.AreEqual(parameters.Properties.Count, 2);
-            Assert.AreEqual(parameters.Properties["ExceptionIndex"], 1);
-            Assert.AreEqual(parameters.Properties["ExceptionCount"], 1);
+            Assert.That(2, Is.EqualTo(parameters.Properties.Count));
+            Assert.That(1, Is.EqualTo(parameters.Properties["ExceptionIndex"]));
+            Assert.That(1, Is.EqualTo(parameters.Properties["ExceptionCount"]));
             Assert.IsFalse(parameters.Properties.ContainsKey("ExceptionTag"));
         }
 
@@ -231,14 +231,14 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedException(new Exception("example exception"), "hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.IsNotEmpty(parameters.Properties);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", parameters.Properties["Key1"]);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("key2")));
-            Assert.AreEqual("Value Two", parameters.Properties["key2"]);
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
             Assert.NotNull(parameters.Exception);
-            Assert.AreEqual("example exception", parameters.Exception.Message);
+            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -255,14 +255,14 @@ namespace NLog.StructuredLogging.Json.Tests
             _logger.ExtendedException(new Exception("example exception"), "hello world", logProperties);
 
             var parameters = (LogEventInfo)Arguments[0];
-            Assert.AreEqual(LogLevel.Error, parameters.Level);
+            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
             Assert.IsNotEmpty(parameters.Properties);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("Key1")));
-            Assert.AreEqual("Value One", parameters.Properties["Key1"]);
-            Assert.AreEqual(1, parameters.Properties.Count(x => x.Key.Equals("key2")));
-            Assert.AreEqual(2, parameters.Properties["key2"]);
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(parameters.Properties["key2"], Is.EqualTo(2));
             Assert.NotNull(parameters.Exception);
-            Assert.AreEqual("example exception", parameters.Exception.Message);
+            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
@@ -29,9 +29,9 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedDebug("hello world", null);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(parameters.Properties, Is.Empty);
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Debug));
+            Assert.That(eventInfo.Properties, Is.Empty);
         }
 
         [Test]
@@ -39,13 +39,13 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedDebug("hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.That(parameters.Properties, Is.Not.Empty);
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Debug));
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -66,9 +66,9 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedInfo("hello world", null);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
-            Assert.That(parameters.Properties, Is.Empty);
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
+            Assert.That(eventInfo.Properties, Is.Empty);
         }
 
         [Test]
@@ -76,13 +76,13 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedInfo("hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
-            Assert.That(parameters.Properties, Is.Not.Empty);
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -97,13 +97,13 @@ namespace NLog.StructuredLogging.Json.Tests
 
             _logger.ExtendedInfo("hello world", props);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
-            Assert.That(parameters.Properties, Is.Not.Empty);
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Info));
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -124,9 +124,9 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedWarn("hello world", null);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Warn));
-            Assert.That(parameters.Properties, Is.Empty);
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Warn));
+            Assert.That(eventInfo.Properties, Is.Empty);
         }
 
         [Test]
@@ -146,9 +146,9 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedError("hello world", null);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.That(parameters.Properties, Is.Empty);
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.That(eventInfo.Properties, Is.Empty);
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -157,13 +157,13 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedError("hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.That(parameters.Properties, Is.Not.Empty);
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -184,10 +184,10 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedException(new Exception("example exception"), "hello world", new {});
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.NotNull(parameters.Exception);
-            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.NotNull(eventInfo.Exception);
+            Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -196,10 +196,10 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedException(new Exception("example exception"), "hello world", null);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.NotNull(parameters.Exception);
-            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.NotNull(eventInfo.Exception);
+            Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -208,10 +208,10 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedException(new Exception("example exception"), "hello world");
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.NotNull(parameters.Exception);
-            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.NotNull(eventInfo.Exception);
+            Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -220,12 +220,12 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedException(new Exception("example exception"), "hello world", new { });
 
-            var parameters = _events.Single();
+            var eventInfo = _events.Single();
 
-            Assert.That(parameters.Properties.Count, Is.EqualTo(2));
-            Assert.That(parameters.Properties["ExceptionIndex"], Is.EqualTo(1));
-            Assert.That(parameters.Properties["ExceptionCount"], Is.EqualTo(1));
-            Assert.That(parameters.Properties.ContainsKey("ExceptionTag"), Is.False);
+            Assert.That(eventInfo.Properties.Count, Is.EqualTo(2));
+            Assert.That(eventInfo.Properties["ExceptionIndex"], Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["ExceptionCount"], Is.EqualTo(1));
+            Assert.That(eventInfo.Properties.ContainsKey("ExceptionTag"), Is.False);
         }
 
         [Test]
@@ -233,15 +233,15 @@ namespace NLog.StructuredLogging.Json.Tests
         {
             _logger.ExtendedException(new Exception("example exception"), "hello world", new { Key1 = "Value One", key2 = "Value Two" });
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.That(parameters.Properties, Is.Not.Empty);
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["key2"], Is.EqualTo("Value Two"));
-            Assert.NotNull(parameters.Exception);
-            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
+            Assert.NotNull(eventInfo.Exception);
+            Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -257,15 +257,15 @@ namespace NLog.StructuredLogging.Json.Tests
 
             _logger.ExtendedException(new Exception("example exception"), "hello world", logProperties);
 
-            var parameters = _events.Single();
-            Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.That(parameters.Properties, Is.Not.Empty);
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["Key1"], Is.EqualTo("Value One"));
-            Assert.That(parameters.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
-            Assert.That(parameters.Properties["key2"], Is.EqualTo(2));
-            Assert.NotNull(parameters.Exception);
-            Assert.That(parameters.Exception.Message, Is.EqualTo("example exception"));
+            var eventInfo = _events.Single();
+            Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
+            Assert.That(eventInfo.Properties, Is.Not.Empty);
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("Key1")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
+            Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
+            Assert.That(eventInfo.Properties["key2"], Is.EqualTo(2));
+            Assert.NotNull(eventInfo.Exception);
+            Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
@@ -28,7 +28,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Debug));
-            Assert.IsEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Empty);
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Info));
-            Assert.IsEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Empty);
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Warn));
-            Assert.IsEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Empty);
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             var parameters = (LogEventInfo)Arguments[0];
             Assert.That(parameters.Level, Is.EqualTo(LogLevel.Error));
-            Assert.IsEmpty(parameters.Properties);
+            Assert.That(parameters.Properties, Is.Empty);
             A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/src/NLog.StructuredLogging.Json.Tests/NestedExceptionTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/NestedExceptionTests.cs
@@ -26,7 +26,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void SimpleException_IsLogged()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new Exception("example exception");
@@ -41,7 +41,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void SimpleException_HasExpectedProperties()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new Exception("example exception");
@@ -57,7 +57,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void InnerException()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new Exception("example exception", new Exception("inner"));
@@ -76,7 +76,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void InnerExceptionTracking()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new Exception("example exception", new Exception("inner"));
@@ -97,7 +97,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void InnerInnerException()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new Exception("example exception", new Exception("inner", new Exception("Inner inner")));
@@ -118,7 +118,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void AggregateExceptionWithOneContained()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new AggregateException("example exception", new Exception("inner 1"));
@@ -137,7 +137,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void AggregateExceptionWithTwoContained()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var ex = new AggregateException("example exception", new Exception("inner 1"), new Exception("inner 2"));
@@ -158,7 +158,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void AggregateAndInnerException()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var exWithInner = new Exception("example exception", new Exception("inner"));
@@ -183,7 +183,7 @@ namespace NLog.StructuredLogging.Json.Tests
         [Test]
         public void DoubleAggregateException()
         {
-            List<LogEventInfo> itemsLogged = new List<LogEventInfo>();
+            var itemsLogged = new List<LogEventInfo>();
             CaptureLogInfoToList(itemsLogged);
 
             var innerAggregate = new AggregateException("inner aggregate", new Exception("inner ag 1"), new Exception("inner ag 2"));


### PR DESCRIPTION
Replace `Assert.AreEqual`, `IsEmpty`, `IsNotEmpty`, `IsFalse` with `Assert.That` throughout.
Now that we know that NUnit will work on .Net core ( http://www.alteridem.net/2017/05/04/test-net-core-nunit-vs2017/ ), might as well modernise it