### PR TITLE
updated the readme section on name clashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ _logger.ExtendedInfo("This text is the message", new { QueueMessageData = someDa
 Don't do this:
 
 ```csharp
-_logger.ExtendedWarn("Order {0} resent", new { OrderId = 1234 } );`
+_logger.ExtendedWarn("Order {0} resent", new { OrderId = 1234 } );
 ```
 
 As there's no format string, the `{0}` is not filled in.

--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ Don't serialise complex objects such as domain objects or DTOs as values, e.g.:
 ```csharp
 var orderDetails = new OrderDetails
   {
-     OrderId = 123,
-	 Time = DateTimeOffset.UtcNow.AddMinutes(45)
+    OrderId = 123,
+    Time = DateTimeOffset.UtcNow.AddMinutes(45)
   };
 
 // let's log the OrderDetails

--- a/README.md
+++ b/README.md
@@ -269,7 +269,23 @@ where we can see that the properties specified in the layout are appended to the
 
 #### Reserved field names
 
-The enforced set of attributes is hard-coded. Supplemental data (from logProperties or the exception data bag), to avoid colliding with this, will be emitted with `data_` or `ex_` prefixes.
+Some attributes are generated automatically. `Message` is the text field, and others are added: `CallSite`, `Level`, `LoggerName`, `Parameters`, `TimeStamp`. If there is an exception, there are several other fields present as well, all starting with `Exception`.
+
+In some cases of name clashes it can keep the value under a different name, e.g. `data_` or `ex_` prefixes. But if this fails the extra value must be discarded.
+
+Don't do this:
+
+```csharp
+_logger.ExtendedInfo("This text is the message", new { Message = someData, TimeStamp = DateTime.Now } );`
+```
+
+Do not add a timestamp at all, this is done automatically, and find a name for the "Message" that does not clash, e.g.:
+
+```csharp
+_logger.ExtendedInfo("This text is the message", new { QueueMessageData = someData } );`
+```
+
+
 
 #### No format strings
 


### PR DESCRIPTION
based on seeing a couple of people do that
"message" means a lot of things - "commit message" or "log message" is some free-form human-generated text. "Queue message" is a structured data object. Sometime we have both.