### PR TITLE
a feature to pass tag as parameter, so that you can tag specific messages(s)

### DIFF
--- a/src/NLog.StructuredLogging.Json/LoggerExtensions.cs
+++ b/src/NLog.StructuredLogging.Json/LoggerExtensions.cs
@@ -35,7 +35,7 @@ namespace NLog.StructuredLogging.Json
         }
 
         public static void Extended(this ILogger logger, LogLevel logLevel, string message, object logProperties,
-            Exception ex = null, string tag = "")
+            Exception ex = null, string exceptionTag = null)
         {
             if (logger == null)
             {
@@ -53,15 +53,15 @@ namespace NLog.StructuredLogging.Json
             else
             {
                 var allExceptions = ConvertException.ToList(ex);
-                if (string.IsNullOrEmpty(tag))
+                if (string.IsNullOrEmpty(exceptionTag))
                 {
-                    tag = Guid.NewGuid().ToString();
+                    exceptionTag = Guid.NewGuid().ToString();
                 }
 
                 for (var index = 0; index < allExceptions.Count; index++)
                 {
                     ExtendedWithException(logger, logLevel, message, logProperties,
-                        allExceptions[index], index + 1, allExceptions.Count, tag);
+                        allExceptions[index], index + 1, allExceptions.Count, exceptionTag);
                 }
             }
         }

--- a/src/NLog.StructuredLogging.Json/LoggerExtensions.cs
+++ b/src/NLog.StructuredLogging.Json/LoggerExtensions.cs
@@ -35,7 +35,7 @@ namespace NLog.StructuredLogging.Json
         }
 
         public static void Extended(this ILogger logger, LogLevel logLevel, string message, object logProperties,
-            Exception ex = null)
+            Exception ex = null, string tag = "")
         {
             if (logger == null)
             {
@@ -53,7 +53,10 @@ namespace NLog.StructuredLogging.Json
             else
             {
                 var allExceptions = ConvertException.ToList(ex);
-                var tag = Guid.NewGuid().ToString();
+                if (string.IsNullOrEmpty(tag))
+                {
+                    tag = Guid.NewGuid().ToString();
+                }
 
                 for (var index = 0; index < allExceptions.Count; index++)
                 {


### PR DESCRIPTION
I had a case that I displayed GUID as error id on a ASP.NET's global error handler, so that I can search the error log with a guid. I think tag in the structured logging is a perfect fit, but Extended method didn't accept tag as parameter. So I've updated the method to be able to accept it. If nothing passes over, it will still generate new guid inside. 