### PR TITLE
Downgrade to use Newtonsoft 9.0.1

### DIFF
--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -9,7 +9,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup> 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup> 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="NLog" Version="5.0.0-beta10" />


### PR DESCRIPTION
Downgrade to depend on `Newtonsoft.Json 9.0.1` not `10.0.x`.
[The reasons are discussed here](https://github.com/NuKeeperDotNet/NuKeeper#when-to-use-nukeeper)

But briefly: this is a library not an application. While we would like the consuming application to use up-to-date libraries for `StucturedLogging.Json` and for `Newtonsoft.Json`, we gain more flexibility if we also allow a previous version of `Newtonsoft.Json` that still works fine with this library.

Since `Newtonsoft.Json 9.0.1` is the lowest version that this library can consume (it adds support for NetStandard), using it allows an app consuming both to choose `Newtonsoft.Json 9.0.1` _or later_. We prefer later, but we should not make that choice for the app, as there may be other factors there.