### PR TITLE
Use nlog version 4.5.0-beta03

### DIFF
--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -10,13 +10,10 @@
   </ItemGroup> 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+     <PackageReference Include="NLog" Version="4.5.0-beta03" />
   </ItemGroup> 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="NLog" Version="5.0.0-beta10" />
- <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
- <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
   </ItemGroup> 
-   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="NLog" Version="4.4.10" />
-  </ItemGroup>
-</Project>
+ </Project>


### PR DESCRIPTION
Use nlog version `4.5.0-beta03` for both platforms.
As this looks like the version that is going to come out of beta with netstandard2 support some time soonish.