### PR TITLE
Update to NLog v 4.5.0-rc01

### DIFF
--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -10,6 +10,6 @@
   </ItemGroup> 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-     <PackageReference Include="NLog" Version="4.5.0-beta07" />
+     <PackageReference Include="NLog" Version="4.5.0-rc01" />
   </ItemGroup> 
  </Project>


### PR DESCRIPTION
Update to NLog v 4.5.0-rc01 from 4.5.0-beta07
This beta dependency is what keeps this package from being released
Soon!