### PR TITLE
example config registers the StructuredLogging assembly

### DIFF
--- a/Examples/nlog.config
+++ b/Examples/nlog.config
@@ -2,7 +2,11 @@
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   autoReload="true">
-
+  
+  <extensions>
+    <add assembly="NLog.StructuredLogging.Json" />
+  </extensions>
+  
   <variable name="log_dir" value="${basedir}..\logs" />
   <variable name="archive_dir" value="${log_dir}\archive" />
   <variable name="human_readable_layout" value="${longdate}|${level}|${logger}|${message}|${onexception:EXCEPTION OCCURRED\:${exception:format=type,message,method,stackTrace:maxInnerExceptionLevel=5:innerFormat=shortType,message,method,stackTrace}}" />


### PR DESCRIPTION
Provide an example of the explicit add of the `NLog.StructuredLogging.Json` assembly as an extension in an `nlog.config` file. 

It seems that we have been relying too heavily on [NLog's feature of "Auto load extensions"](http://nlog-project.org/2015/06/09/nlog-4-has-been-released.html), where "Assemblies with the name _NLog*.dll_ are loaded automatically".

This is how we typically get the ` layout="${structuredlogging.json}"` to work in `nlog.config`.

This fails:
*  when using a version of nlog less than 4.0. The fix is to update nlog. Sometime this is is in another package that in turn uses nlog.

* it is ["not working yet for .NET Core."](https://github.com/NLog/NLog/wiki/Register-your-custom-component). We have to register in `nlog.config` in .Net core.

The failure symptom is that the `internal-nlog.txt` file contains lines like `Error parsing layout structuredlogging.json will be ignored. Exception: System.ArgumentException: LayoutRenderer cannot be found: 'structuredlogging.json'`

  
  