### PR TITLE
Fix for "Field names contains dot"

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperExceptionDataTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperExceptionDataTests.cs
@@ -76,7 +76,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
             Assert.That(result.ContainsKey("data_name2"), Is.True);
 
             Assert.That(result["data_name1"], Is.EqualTo("test1"));
-            Assert.That(result["data_name2"], Is.EqualTo("test1"));
+            Assert.That(result["data_name2"], Is.EqualTo("test2"));
         }
 
         private static LogEventInfo MakeLogEventInfoWithException(Exception ex)

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperExceptionDataTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperExceptionDataTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NLog.StructuredLogging.Json.Helpers;
 using NUnit.Framework;
 
@@ -44,6 +44,39 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
 
             Assert.That(result["ExKey1"], Is.EqualTo("valueOverrridenInProperties"));
             Assert.That(result["ExKey2"], Is.EqualTo("value2"));
+        }
+
+        [Test]
+        public void When_ExceptionDataKeyContainDots()
+        {
+            var logEventInfo = MakeLogEventInfoWithException(ExceptionWithData());
+            logEventInfo.Properties.Clear();
+            logEventInfo.Properties.Add("data.name1", "test1");
+            var result = Mapper.ToDictionary(logEventInfo);
+
+            Assert.That(result.ContainsKey("data.name1"), Is.False);
+            Assert.That(result.ContainsKey("data_name1"), Is.True);
+
+            Assert.That(result["data_name1"], Is.EqualTo("test1"));
+        }
+
+        [Test]
+        public void When_ExceptionDataKeysContainDots()
+        {
+            var logEventInfo = MakeLogEventInfoWithException(ExceptionWithData());
+            logEventInfo.Properties.Clear();
+            logEventInfo.Properties.Add("data.name1", "test1");
+            logEventInfo.Properties.Add("data.name2", "test2");
+
+            var result = Mapper.ToDictionary(logEventInfo);
+
+            Assert.That(result.ContainsKey("data.name1"), Is.False);
+            Assert.That(result.ContainsKey("data.name2"), Is.False);
+            Assert.That(result.ContainsKey("data_name1"), Is.True);
+            Assert.That(result.ContainsKey("data_name2"), Is.True);
+
+            Assert.That(result["data_name1"], Is.EqualTo("test1"));
+            Assert.That(result["data_name2"], Is.EqualTo("test1"));
         }
 
         private static LogEventInfo MakeLogEventInfoWithException(Exception ex)

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -81,6 +81,13 @@ namespace NLog.StructuredLogging.Json.Helpers
 
         public static void HarvestStringToDictionary(IDictionary<string, object> dest, string key, string value, string keyPrefixWhenCollision)
         {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return;
+            }
+
+            key = SafeCharsInKey(key);
+
             if (!dest.ContainsKey(key))
             {
                 dest.Add(key, value);
@@ -92,6 +99,11 @@ namespace NLog.StructuredLogging.Json.Helpers
             {
                 dest.Add(prefixedKey, value);
             }
+        }
+
+        private static string SafeCharsInKey(string rawKey)
+        {
+            return rawKey.Replace('.', '_');
         }
     }
 }


### PR DESCRIPTION
A fix for #29 - see discussion there.

This fix is for the case where these dotted names are in exception data, where it's not easy for the caller to just pick a better name. So we turn `.` to `_`  upfront.

I.e. if you manage to do `logger.ExtendedInfo("Sending order", new { Bad.Name = 4567 } );` you're on your own and should just fix your code to send a better name. 

But if you are logging an exception which comes out of a library, and the exception contains data items with dotted names, the dots will be changed to `_`. This seems like the best way to do it, other options are not nearly as good.
  
  