### PR TITLE
SourceLink.Embed.AllSourceFiles is a private asset

### DIFF
--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -6,10 +6,10 @@
    <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup> 
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
      <PackageReference Include="NLog" Version="4.5.0" />
-     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.0" />
-  </ItemGroup> 
+     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.0" PrivateAssets="All" />
+  </ItemGroup>
  </Project>


### PR DESCRIPTION
`SourceLink.Embed.AllSourceFiles` is a private asset
things downstream of this package won't need it
See https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files