### PR TITLE
Fix ref to Mono.Cecil

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -23,8 +23,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/325 -->
-    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />


### PR DESCRIPTION
remove this ref. 
Seems to be causing issues with windows test run, e.g. on appveyor
Check details on appveyor and travis before merging, test runs should succeed with details!
recent runs on appveyor ... did not.

It's not needed any more: fixed in https://www.nuget.org/packages/NUnit3TestAdapter/3.10.0 as per https://github.com/nunit/nunit3-vs-adapter/issues/325#issuecomment-372641371
