### PR TITLE
Apply sealed to DictionaryConverter

### DIFF
--- a/src/NLog.StructuredLogging.Json/Helpers/ObjectToDictionaryConverter.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/ObjectToDictionaryConverter.cs
@@ -34,7 +34,7 @@ namespace NLog.StructuredLogging.Json.Helpers
         }
     }
 
-    public class DictionaryConverter
+    public sealed class DictionaryConverter
     {
         private static readonly MethodInfo MethodInfo = typeof(Dictionary<string, object>)
             .GetMethod("Add", BindingFlags.Public | BindingFlags.Instance, null, new[] { typeof(string), typeof(object) }, null);


### PR DESCRIPTION
This class can be sealed, as it's not part of the api that we want people to use
and should never be subclassed
might help performance
