### PR TITLE
propagate message templates

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/MessageTemplateTest.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/MessageTemplateTest.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+
+namespace NLog.StructuredLogging.Json.Tests.EndToEnd
+{
+    public abstract class MessageTemplateTest : EndToEndTests
+    {
+        private string _output;
+
+        protected override void When()
+        {
+            var logInfo = new LogEventInfo
+            {
+                Level = LogLevel.Info,
+                Message = "A message with {PropA} and {PropB} embedded",
+                Parameters = new object[] {1, "two"}
+            };
+
+            Sut.Log(logInfo);
+            var lines = LogManager.Configuration.LogMessage(TargetName);
+            _output = lines[0];
+        }
+
+        [Test]
+        public void OutputHasText()
+        {
+            Assert.That(_output, Does.Contain("\"Message\":\"A message with 1 and \\\"two\\\" embedded\""));
+            Assert.That(_output, Does.Contain("\"MessageTemplate\":\"A message with {PropA} and {PropB} embedded"));
+            Assert.That(_output, Does.Contain("\"PropA\":\"1"));
+            Assert.That(_output, Does.Contain("\"PropB\":\"two"));
+            Assert.That(_output, Does.Not.Contain("Parameters"));
+        }
+    }
+}

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageTemplateInLayoutRenderer.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageTemplateInLayoutRenderer.cs
@@ -2,7 +2,7 @@ using NLog.Layouts;
 
 namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayoutRenderer
 {
-    public class UnicodePropertiesInLayoutRenderer : UnicodePropertiesAreSerialised
+    public class MessageTemplateInLayoutRenderer : MessageTemplateTest
     {
         protected override Layout GivenLayout()
         {

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -15,8 +15,17 @@ namespace NLog.StructuredLogging.Json.Helpers
                 {"TimeStamp", timestampUtcIso8601 },
                 {"Level", source.Level.ToString()},
                 {"LoggerName", source.LoggerName},
-                {"Message", source.FormattedMessage}
             };
+
+            if (string.Equals(source.Message, source.FormattedMessage))
+            {
+                result.Add("Message", source.Message);
+            }
+            else
+            {
+                result.Add("Message", source.FormattedMessage);
+                result.Add("MessageTemplate", source.Message);
+            }
 
             if (source.Exception != null)
             {

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +18,7 @@ namespace NLog.StructuredLogging.Json.Helpers
                 {"LoggerName", source.LoggerName},
             };
 
-            if (string.Equals(source.Message, source.FormattedMessage))
+            if (string.Equals(source.Message, source.FormattedMessage, StringComparison.Ordinal))
             {
                 result.Add("Message", source.Message);
             }

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -21,6 +21,10 @@ namespace NLog.StructuredLogging.Json.Helpers
             if (string.Equals(source.Message, source.FormattedMessage, StringComparison.Ordinal))
             {
                 result.Add("Message", source.Message);
+                if (source.Parameters != null)
+                {
+                    result.Add("Parameters", string.Join(",", source.Parameters.Select(Convert.ValueAsString)));
+                }
             }
             else
             {
@@ -35,11 +39,6 @@ namespace NLog.StructuredLogging.Json.Helpers
                 result.Add("ExceptionMessage", source.Exception.Message);
                 result.Add("ExceptionStackTrace", source.Exception.StackTrace);
                 result.Add("ExceptionFingerprint", ConvertException.ToFingerprint(source.Exception));
-            }
-
-            if (source.Parameters != null)
-            {
-                result.Add("Parameters", string.Join(",", source.Parameters.Select(Convert.ValueAsString)));
             }
 
             if (source.StackTrace != null)

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -15,21 +15,19 @@ namespace NLog.StructuredLogging.Json.Helpers
             {
                 {"TimeStamp", timestampUtcIso8601 },
                 {"Level", source.Level.ToString()},
-                {"LoggerName", source.LoggerName},
+                {"LoggerName", source.LoggerName}
             };
 
-            if (string.Equals(source.Message, source.FormattedMessage, StringComparison.Ordinal))
-            {
-                result.Add("Message", source.Message);
-                if (source.Parameters != null)
-                {
-                    result.Add("Parameters", string.Join(",", source.Parameters.Select(Convert.ValueAsString)));
-                }
-            }
-            else
+            var hasTemplate = !string.Equals(source.Message, source.FormattedMessage, StringComparison.Ordinal);
+
+            if (hasTemplate)
             {
                 result.Add("Message", source.FormattedMessage);
                 result.Add("MessageTemplate", source.Message);
+            }
+            else
+            {
+                result.Add("Message", source.Message);
             }
 
             if (source.Exception != null)
@@ -39,6 +37,11 @@ namespace NLog.StructuredLogging.Json.Helpers
                 result.Add("ExceptionMessage", source.Exception.Message);
                 result.Add("ExceptionStackTrace", source.Exception.StackTrace);
                 result.Add("ExceptionFingerprint", ConvertException.ToFingerprint(source.Exception));
+            }
+
+            if (!hasTemplate && source.Parameters != null)
+            {
+                result.Add("Parameters", string.Join(",", source.Parameters.Select(Convert.ValueAsString)));
             }
 
             if (source.StackTrace != null)


### PR DESCRIPTION
See #124

~~It needs tests~~ It has a test

My thinking now is 
* We resisted the [MessageTemplate](https://messagetemplates.org/) design, because it means that you have the overhead of message string being serialised twice in two different formats.
* However message template has caught  on as a standard - it is supported by `NLog`, `SeriLog` etc.
* it is also supported by the `Microsoft.Extensions.Logging.Abstractions.ILogger` abstraction, and so log messages are going to find their way into the `StructuredLoggingLayoutRenderer` having originated as structured, templated messages sent to an `ILogger`.  New code in `JustSaying` is one example. This library should support this case.
* With a clean slate, there are probably better ways to do things now than to use this library, but tweaks to support existing users in new scenarios  are in scope. e.g. updates to JustSaying, or conversion to .NET core in an app that heavily uses `NLog.StructuredLogging.Json`.

This library will now work fine with `ILogger` and templated messages. Here's a demo: https://github.com/AnthonySteele/StructuredNLogCore