### PR TITLE
Numbers and booleans not output as strings

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/MessageTemplateTest.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/MessageTemplateTest.cs
@@ -25,7 +25,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             Assert.That(_output, Does.Contain("\"Message\":\"A message with 1 and \\\"two\\\" embedded\""));
             Assert.That(_output, Does.Contain("\"MessageTemplate\":\"A message with {PropA} and {PropB} embedded"));
-            Assert.That(_output, Does.Contain("\"PropA\":\"1"));
+            Assert.That(_output, Does.Contain("\"PropA\":1"));
             Assert.That(_output, Does.Contain("\"PropB\":\"two"));
             Assert.That(_output, Does.Not.Contain("Parameters"));
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/NestedExceptionEndToEndTests.cs
@@ -30,6 +30,15 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
 
             testEx.Data.Add("ex_key_1", "ex_data_1");
             testEx.Data.Add("ex_key_2", "ex_data_2");
+            testEx.Data.Add("ex_key_3", 3);
+            testEx.Data.Add("ex_key_4", 4d);
+            testEx.Data.Add("ex_key_5", 5f);
+            testEx.Data.Add("ex_key_6", 6m);
+            testEx.Data.Add("ex_key_7", 7u);
+            testEx.Data.Add("ex_key_8", 8ul);
+            testEx.Data.Add("ex_key_9", (byte)9);
+            testEx.Data.Add("ex_key_10", (sbyte)10);
+            testEx.Data.Add("ex_key_11", true);
 
             return PutStackTraceOnException(testEx);
         }
@@ -50,7 +59,11 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
         {
             for (var i = 0; i < Iterations; i++)
             {
-                Sut.ExtendedException(_exception, Message, new { PropertyOne = "one", PropertyTwo = 2, Iteration = i });
+                Sut.ExtendedException(_exception, Message,
+                    new
+                    {
+                        PropertyOne = "one", PropertyTwo = 2, PropertyThree = true, Iteration = i
+                    });
             }
             LogManager.Flush();
             Result = LogManager.Configuration.LogMessage(TargetName);
@@ -145,6 +158,15 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd
                 {
                     line.ShouldMatch(@"""ex_key_1"":""ex_data_1");
                     line.ShouldMatch(@"""ex_key_2"":""ex_data_2");
+                    line.ShouldMatch(@"""ex_key_3"":3");
+                    line.ShouldMatch(@"""ex_key_4"":4.0");
+                    line.ShouldMatch(@"""ex_key_5"":5.0");
+                    line.ShouldMatch(@"""ex_key_6"":6");
+                    line.ShouldMatch(@"""ex_key_7"":7");
+                    line.ShouldMatch(@"""ex_key_8"":8");
+                    line.ShouldMatch(@"""ex_key_9"":9");
+                    line.ShouldMatch(@"""ex_key_10"":10");
+                    line.ShouldMatch(@"""ex_key_11"":true");
                 }
             }
         }

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayout/WithFailingLayout.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NLog.Config;
 using NLog.Layouts;
 using NLog.StructuredLogging.Json.Tests.JsonWithProperties;
@@ -33,7 +33,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
             Assert.That(output, Does.StartWith(
                 "{\"success1\":\"success1\",\"TimeStamp\":\""));
             Assert.That(output, Does.EndWith(
-                "\"prop1\":\"value1s\",\"prop2s\":\"2\"}"));
+                "\"prop1\":\"value1s\",\"prop2s\":2}"));
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
 
             Assert.That(output, Does.Contain("\"Message\":\"test message\""));
             Assert.That(output, Does.Contain("\"flat1\":\"flat1\",\"TimeStamp\":\""));
-            Assert.That(output, Does.EndWith("\"prop1\":\"value1\",\"prop2\":\"2\"}"));
+            Assert.That(output, Does.EndWith("\"prop1\":\"value1\",\"prop2\":2}"));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
 
             Assert.That(output, Does.Contain("\"Message\":\"test message\""));
             Assert.That(output, Does.Contain("\"flat1\":\"flat1\",\"TimeStamp\":\""));
-            Assert.That(output, Does.EndWith("\"prop1\":\"value1\",\"prop2\":\"2\"}"));
+            Assert.That(output, Does.EndWith("\"prop1\":\"value1\",\"prop2\":2}"));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayout
             Assert.That(output, Does.StartWith(
                 "{\"duplicated\":\"value1\",\"attributes_duplicated\":\"value2\",\"TimeStamp\":\""));
             Assert.That(output, Does.EndWith(
-                "\"prop1\":\"value1\",\"prop2\":\"2\"}"));
+                "\"prop1\":\"value1\",\"prop2\":2}"));
         }
 
         private void GivenLoggingIsConfiguredForTest(Target target, bool layoutThrowsExceptions)

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageContainsJson.cs
@@ -31,7 +31,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayoutRenderer
         {
             foreach (var line in Result)
             {
-                Assert.That(line.Length, Is.InRange(550, 1450));
+                Assert.That(line.Length, Is.InRange(550, 1452));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperStandardTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperStandardTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog.StructuredLogging.Json.Helpers;
@@ -21,7 +21,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void WhenConverted_TheRightNumberOfItemsAreReturned()
         {
-            Assert.That(_result.Count, Is.EqualTo(12));
+            Assert.That(_result.Count, Is.EqualTo(13));
         }
 
         [Test]
@@ -50,9 +50,11 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
             Assert.False(_result.Keys.Contains("Properties"));
             Assert.True(_result.Keys.Contains("PropertyOne"));
             Assert.True(_result.Keys.Contains("PropertyTwo"));
+            Assert.True(_result.Keys.Contains("PropertyThree"));
 
             Assert.That(_result["PropertyOne"], Is.EqualTo("This value is in property one"));
-            Assert.That(_result["PropertyTwo"], Is.EqualTo("2"));
+            Assert.That(_result["PropertyTwo"], Is.EqualTo(2));
+            Assert.That(_result["PropertyThree"], Is.EqualTo(true));
         }
 
         [Test]
@@ -71,8 +73,11 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
                 Level = LogLevel.Error,
                 LoggerName = "ExampleLoggerName",
                 Message = "Example Message",
-                Parameters = new object[] { "One", 1234 },
-                Properties = { { "PropertyOne", "This value is in property one" }, { "PropertyTwo", 2 } },
+                Parameters = new object[] {"One", 1234},
+                Properties =
+                {
+                    {"PropertyOne", "This value is in property one"}, {"PropertyTwo", 2}, {"PropertyThree", true}
+                },
                 TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 6),
             };
         }

--- a/src/NLog.StructuredLogging.Json.Tests/LayoutRendererCallSiteTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LayoutRendererCallSiteTests.cs
@@ -17,7 +17,6 @@ namespace NLog.StructuredLogging.Json.Tests
         [SetUp]
         public void SetUp()
         {
-
             LogEvent = new LogEventInfo
             {
                 Exception = new Exception(),

--- a/src/NLog.StructuredLogging.Json.Tests/LayoutRendererTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LayoutRendererTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -56,8 +56,8 @@ With lots of possibly bad things in it";
                 Level = LogLevel.Error,
                 LoggerName = "ExampleLoggerName",
                 Message = Message,
-                Parameters = new object[] { "One", 1234 },
-                Properties = { { "PropertyOne", "one" }, { "PropertyTwo", 2 } },
+                Parameters = new object[] {"One", 1234},
+                Properties = {{"PropertyOne", "one"}, {"PropertyTwo", 2}, {"PropertyThree", true}},
                 TimeStamp = new DateTime(2014, 1, 2, 3, 4, 5, 623, DateTimeKind.Utc)
             };
 
@@ -96,7 +96,7 @@ With lots of possibly bad things in it";
                 "\"ExceptionMessage\":\"Outer Exception\"," +
                 "\"ExceptionStackTrace\":null," +
                 "\"ExceptionFingerprint\":\"55179621c796d669d13aee15725c01ba4524b44f\"," +
-                "\"Parameters\":\"One,1234\",\"PropertyOne\":\"one\",\"PropertyTwo\":\"2\"}";
+                "\"Parameters\":\"One,1234\",\"PropertyOne\":\"one\",\"PropertyTwo\":2,\"PropertyThree\":true}";
 
 
             Assert.That(Result, Is.EqualTo(expected));

--- a/src/NLog.StructuredLogging.Json/Helpers/ObjectExtensions.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/ObjectExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace NLog.StructuredLogging.Json.Helpers
+{
+    public static class ObjectExtensions
+    {
+        public static bool IsNonStringValueType(this object value)
+        {
+            switch (System.Convert.GetTypeCode(value))
+            {
+                case TypeCode.Boolean:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt64:
+                case TypeCode.UInt32:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                    return true;
+
+                default: return false;
+            }
+        }
+    }
+}

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>


### PR DESCRIPTION
This is a fix to issue #129. Currently all data, regardless of type is output to Json as strings. This is causing issues in kibana where we are not able to index fields using the correct data type.

Boolean and numeric data is no longer treated as a string and therefore not wrapped in quotes.

e.g. when an order id is supplied as type int, instead of output `"OrderId": "12345",`,  it should be `"OrderId": 12345,`

This is a breaking change and affects the output format of the Json.