### PR TITLE
Manually update FakeItEasy

### DIFF
--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsContextTests.cs
@@ -52,7 +52,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("a3")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["a3"], Is.EqualTo("34"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("b3")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["b3"], Is.EqualTo("34"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("c3")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["c3"], Is.EqualTo("34"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("log_context_Key1")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["log_context_Key1"], Is.EqualTo("Value MDLC"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/LoggerExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,7 +56,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace NLog.StructuredLogging.Json.Tests
             var eventInfo = _events.Single();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
             Assert.That(eventInfo.Properties, Is.Empty);
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -190,7 +190,7 @@ namespace NLog.StructuredLogging.Json.Tests
             var eventInfo = _events.Single();
             Assert.That(eventInfo.Level, Is.EqualTo(LogLevel.Error));
             Assert.That(eventInfo.Properties, Is.Empty);
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -205,7 +205,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Properties["Key1"], Is.EqualTo("Value One"));
             Assert.That(eventInfo.Properties.Count(x => x.Key.Equals("key2")), Is.EqualTo(1));
             Assert.That(eventInfo.Properties["key2"], Is.EqualTo("Value Two"));
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -232,7 +232,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Exception, Is.Not.Null);
             Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -247,7 +247,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Exception, Is.Not.Null);
             Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -262,7 +262,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Exception, Is.Not.Null);
             Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
 
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -295,7 +295,7 @@ namespace NLog.StructuredLogging.Json.Tests
 
             Assert.That(eventInfo.Exception, Is.Not.Null);
             Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]
@@ -322,7 +322,7 @@ namespace NLog.StructuredLogging.Json.Tests
             Assert.That(eventInfo.Exception, Is.Not.Null);
 
             Assert.That(eventInfo.Exception.Message, Is.EqualTo("example exception"));
-            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => _logger.Log(A<LogEventInfo>.Ignored)).MustHaveHappened(1, Times.Exactly);
         }
 
         [Test]

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -19,7 +19,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />


### PR DESCRIPTION
Manually update `FakeItEasy` to `5.1` from `4.5`
After NuKeeper flagged up that there is an update, but it involves code changes due to `Repeated` being deprecated