### PR TITLE
Config for benchmarking with a null target

### DIFF
--- a/src/Benchmark/nlog.config
+++ b/src/Benchmark/nlog.config
@@ -2,45 +2,15 @@
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   autoReload="true">
-  
+
   <extensions>
     <add assembly="NLog.StructuredLogging.Json" />
   </extensions>
-  
-  <variable name="log_dir" value="${basedir}..\logs" />
-  <variable name="archive_dir" value="${log_dir}\archive" />
-  <variable name="human_readable_layout" value="${longdate}|${level}|${logger}|${message}|${onexception:EXCEPTION OCCURRED\:${exception:format=type,message,method,stackTrace:maxInnerExceptionLevel=5:innerFormat=shortType,message,method,stackTrace}}" />
-
-  <targets async="true">
-    <target name="nxlog_json"
-      fileName="${log_dir}\nxlog\${level:lowercase=true}.log"
-      encoding="utf-8"
-      xsi:type="File"
-      layout="${structuredlogging.json}"
-      archiveEvery="Hour"
-      archiveNumbering="Date"
-      archiveDateFormat="yyyyMMdd-HHmm"
-      archiveFileName="${archive_dir}\nxlog\{#####}-${level:lowercase=true}.log"
-      maxArchiveFiles="36"
-      concurrentWrites="false"
-      keepFileOpen="false" />
-
-    <target name="human_text_file"
-      fileName="${log_dir}\human-readable\${level:lowercase=true}.log"
-      encoding="utf-8"
-      xsi:type="File"
-      layout="${human_readable_layout}"
-      archiveEvery="Hour"
-      archiveNumbering="Date"
-      archiveDateFormat="yyyyMMdd-HHmm"
-      archiveFileName="${archive_dir}\human-readable\{#####}-${level:lowercase=true}.log"
-      maxArchiveFiles="36"
-      concurrentWrites="false"
-      keepFileOpen="false" />
+  <targets>
+   <target xsi:type="Null" name="testLogger" formatMessage="true"
+      layout="${structuredlogging.json}" />
   </targets>
-
   <rules>
-    <logger name="*" minlevel="Info" writeTo="nxlog_json" />
-    <logger name="*" minlevel="Info" writeTo="human_text_file" />
+    <logger name="*" minlevel="Info" writeTo="testLogger" />
   </rules>
 </nlog>


### PR DESCRIPTION
Config for benchmarking with [a null target](https://github.com/NLog/NLog/wiki/Null-target) instead of file targets, so that we're not benchmark the write-to-file step. As per this comment: https://github.com/justeat/NLog.StructuredLogging.Json/pull/140#issuecomment-466790799 

If we log to file here, we are effectively benchmarking a lot of `NLog` code, which is not the intent. It will be easier to pick out changes in the `NLog.StructuredLogging.Json` code if we benchmark just that part - i.e. generating the log entry and formatting it.

A replacement for #140 


FWIW, timings look a bit like this:


|                        Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------ |----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|                       LogInfo |  3.223 us | 0.0669 us | 0.0593 us |      0.6180 |           - |           - |             2.86 KB |
|               LogExtendedInfo | 19.273 us | 0.3949 us | 0.7122 us |      2.2278 |           - |           - |             10.4 KB |
| LogExtendedInfoWithProperties | 21.810 us | 0.3527 us | 0.3299 us |      2.7466 |           - |           - |            12.74 KB |
|                  LogException |  7.533 us | 0.1473 us | 0.1753 us |      1.3199 |           - |           - |              6.1 KB |
|          LogExtendedException | 27.288 us | 0.3711 us | 0.3289 us |      3.0823 |           - |           - |            14.27 KB |
|    LogExceptionWithProperties | 30.476 us | 0.5888 us | 0.6046 us |      3.5400 |           - |           - |            16.52 KB |
