### PR TITLE
Prepare for v4

### DIFF
--- a/SetAppVeyorBuildVersion.ps1
+++ b/SetAppVeyorBuildVersion.ps1
@@ -18,16 +18,23 @@ if ($env:APPVEYOR_PULL_REQUEST_NUMBER){
   $buildNumber += "-" + (Generate-RandomCharacters -Length 8)
 }
 
+
 if ($env:APPVEYOR_REPO_TAG -ne "true") {
-  if ($versionSuffix -ne "") {
+  if ($versionSuffix -ne $null) {
     $versionSuffix += "-build$buildNumber"
   }
-  if ($versionSuffix -eq "") {
+  else {
     $versionSuffix = "build$buildNumber"
   }
 }
+else {
+  if ($env:APPVEYOR_REPO_TAG_NAME.Contains("-")) {
+    $dashIndex = $env:APPVEYOR_REPO_TAG_NAME.IndexOf("-")
+    $versionSuffix = $env:APPVEYOR_REPO_TAG_NAME.Substring($dashIndex + 1)
+  }
+}
 
-if ($versionSuffix -ne "") {
+if ($versionSuffix -ne $null) {
   $version = "$versionPrefix-$versionSuffix"
 } else {
   $version = $versionPrefix

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-version: 3.0.{build}
+version: 4.0.{build}
 configuration: Release
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/version.props
+++ b/version.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <VersionPrefix>4.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 


### PR DESCRIPTION
- `SetAppVeyorBuildVersion.ps1` script must detect beta tags. This is not working now: [this build](https://ci.appveyor.com/project/justeattech/nlog-structuredlogging-json/builds/22744424#L190) should have number `4.0.0-beta01`. Used code as in `JustSaying`
- version in `appveyor.yml` set to `4.0.{build}`
- in `version.props`, lock the `AssemblyVersion` to exactly `4.0.0`