### PR TITLE
Use version suffix in pack script

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -123,8 +123,14 @@ function DotNetTestWithCoverage {
 }
 
 function DotNetPack {
-    param([string]$Project, [string]$Configuration)
-    & $dotnet pack $Project --output $OutputPath --configuration $Configuration --include-symbols --include-source
+    param([string]$Project)
+
+    if ($VersionSuffix) {
+        & $dotnet pack $Project --output $OutputPath --configuration $Configuration --version-suffix "$VersionSuffix"
+    }
+    else {
+        & $dotnet pack $Project --output $OutputPath --configuration $Configuration
+    }
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet pack failed with exit code $LASTEXITCODE"
     }
@@ -159,6 +165,6 @@ if ($RunTests -eq $true) {
 if ($CreatePackages -eq $true) {
     Write-Host "Creating $($packageProjects.Count) package(s)..." -ForegroundColor Green
     ForEach ($project in $packageProjects) {
-        DotNetPack $project $Configuration
+        DotNetPack $project
     }
 }


### PR DESCRIPTION
Use version suffix in the `dotnet pack` part of the script
as per script in `JustSaying`