### PR TITLE
Version props for v4 betas

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -123,7 +123,9 @@ function DotNetTestWithCoverage {
 }
 
 function DotNetPack {
-    param([string]$Project, [string]$Configuration)
+    param([string]$Project)
+        Write-Host "Packing project $Project"
+
     & $dotnet pack $Project --output $OutputPath --configuration $Configuration --include-symbols --include-source
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet pack failed with exit code $LASTEXITCODE"
@@ -159,6 +161,6 @@ if ($RunTests -eq $true) {
 if ($CreatePackages -eq $true) {
     Write-Host "Creating $($packageProjects.Count) package(s)..." -ForegroundColor Green
     ForEach ($project in $packageProjects) {
-        DotNetPack $project $Configuration
+        DotNetPack $project
     }
 }

--- a/SetAppVeyorBuildVersion.ps1
+++ b/SetAppVeyorBuildVersion.ps1
@@ -40,4 +40,6 @@ if ($versionSuffix -ne $null) {
   $version = $versionPrefix
 }
 
+Write-Host "Version is $version" -ForegroundColor Green
+
 Update-AppveyorBuild -Version "$version"

--- a/version.props
+++ b/version.props
@@ -9,5 +9,6 @@
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
     <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' != 'true' AND '$(VersionSuffix)' != '' ">$(VersionSuffix)-build$(BuildNumber)</VersionSuffix>
     <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' != 'true' AND '$(VersionSuffix)' == '' ">build$(BuildNumber)</VersionSuffix>
-  </PropertyGroup>
+    <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' == 'true' AND '$(APPVEYOR_REPO_TAG_NAME)' != '' AND '$(APPVEYOR_REPO_TAG_NAME.Contains(`-`))' == 'true' ">$(APPVEYOR_REPO_TAG_NAME.Substring($(APPVEYOR_REPO_TAG_NAME.IndexOf(`-`))).Substring(1))</VersionSuffix>
+   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Build props tweaking, for v4 betas, particularly 

* ` version.props` needs a rule for when there _is_ a  `APPVEYOR_REPO_TAG_NAME`.
* `DotNetPack` does not neet a `Configuration` param, there is a global (to the build script) var of the same name.

More troubleshooting by comparing to `JustSaying`