### PR TITLE
Target .Net 4.5.0

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -73,7 +73,7 @@ function DotNetTestFullFramework {
         $dotnetPath = (Get-Command "dotnet.exe").Source
     }
 
-    & $dotnetPath test $Project --framework net471
+    & $dotnetPath test $Project --framework net46
   }
 
 function DotNetTestWithCoverage {
@@ -147,7 +147,7 @@ $packageProjects = @(
 Write-Host "Building $($projects.Count) projects..." -ForegroundColor Green
 ForEach ($project in $projects) {
     DotNetBuild $project $Configuration "netstandard2.0"
-    DotNetBuild $project $Configuration "net452"
+    DotNetBuild $project $Configuration "net45"
 }
 
 if ($RunTests -eq $true) {

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
@@ -20,7 +20,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void EmptyParamsAreParsed()
         {
-            var input = Array.Empty<object>();
+            var input = new object[0];
             var actualParams = ProcessParams(input);
 
             Assert.That(actualParams, Is.Empty);

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
@@ -47,7 +47,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void NullForParamsIsParsed()
         {
-            var input = Array.Empty<object>();
+            var input = new object[] { null };
             var actualParams = ProcessParams(input);
 
             Assert.That(actualParams, Is.Empty);

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
@@ -20,7 +20,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void EmptyParamsAreParsed()
         {
-            var input = new object[0];
+            var input = Array.Empty<object>();
             var actualParams = ProcessParams(input);
 
             Assert.That(actualParams, Is.Empty);

--- a/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/Helpers/MapperParametersTests.cs
@@ -47,7 +47,7 @@ namespace NLog.StructuredLogging.Json.Tests.Helpers
         [Test]
         public void NullForParamsIsParsed()
         {
-            var input = new object[] { null };
+            var input = Array.Empty<object>();
             var actualParams = ProcessParams(input);
 
             Assert.That(actualParams, Is.Empty);

--- a/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
+++ b/src/NLog.StructuredLogging.Json.Tests/NLog.StructuredLogging.Json.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net471</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
-   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
The full framework target can be `.Net 4.5.0`, not `4.5.2`  for maximum compatibility with clients using `4.5.x` versions.

This should not affect existing users on framework v `4.5.2` or later, but allows e.g. client using framework `4.5` or `4.5.1`

Tests are now using framework `4.6` since this is as low as you can go and still use `Array.Empty<>`

For issue #154