### PR TITLE
 Reduced memory allocation by skipping string-allocation

### DIFF
--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NLog.StructuredLogging.Json\NLog.StructuredLogging.Json.csproj" />

--- a/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageContainsJson.cs
+++ b/src/NLog.StructuredLogging.Json.Tests/EndToEnd/ViaLayoutRenderer/MessageContainsJson.cs
@@ -31,7 +31,7 @@ namespace NLog.StructuredLogging.Json.Tests.EndToEnd.ViaLayoutRenderer
         {
             foreach (var line in Result)
             {
-                Assert.That(line.Length, Is.InRange(550, 1452));
+                Assert.That(line.Length, Is.InRange(550, 1500));
             }
         }
     }

--- a/src/NLog.StructuredLogging.Json/HasherLayoutRenderer.cs
+++ b/src/NLog.StructuredLogging.Json/HasherLayoutRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using NLog.Config;
 using NLog.StructuredLogging.Json.Helpers;
 using NLog.LayoutRenderers;
@@ -9,7 +9,7 @@ namespace NLog.StructuredLogging.Json
 {
     [LayoutRenderer("hasher")]
     [ThreadAgnostic]
-    [AppDomainFixedOutput]
+    [ThreadSafe]
     public class HasherLayoutRenderer : WrapperLayoutRendererBase
     {
         public Layout Text

--- a/src/NLog.StructuredLogging.Json/Helpers/ConvertJson.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/ConvertJson.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -6,15 +7,28 @@ namespace NLog.StructuredLogging.Json.Helpers
 {
     public static class ConvertJson
     {
-        private static readonly JsonSerializerSettings LogSettings = new JsonSerializerSettings
+        internal static readonly JsonSerializerSettings LogSettings = new JsonSerializerSettings
         {
             ContractResolver = new DefaultContractResolver(),
             Formatting = Formatting.None
         };
 
+        internal static JsonSerializer CreateJsonSerializer() => JsonSerializer.CreateDefault(LogSettings);
+
         public static string Serialize(Dictionary<string, object> data)
         {
             return JsonConvert.SerializeObject(data, LogSettings);
+        }
+
+        public static void Serialize(Dictionary<string, object> data, System.Text.StringBuilder sb, JsonSerializer jsonSerializer)
+        {
+            using (var sw = new StringWriter(sb))
+            {
+                using (JsonWriter writer = new JsonTextWriter(sw))
+                {
+                    jsonSerializer.Serialize(writer, data);
+                }
+            }
         }
     }
 }

--- a/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
+++ b/src/NLog.StructuredLogging.Json/Helpers/Mapper.cs
@@ -51,9 +51,12 @@ namespace NLog.StructuredLogging.Json.Helpers
                 result.Add("CallSite", StackHelper.CallSiteName(source.StackTrace));
             }
 
-            HarvestToDictionary(source.Properties, result, "data_");
+            if (source.HasProperties)
+            {
+                HarvestToDictionary(source.Properties, result, "data_");
+            }
 
-            if (source.Exception != null)
+            if (source.Exception?.Data?.Count > 0)
             {
                 HarvestToDictionary(source.Exception.Data, result, "ex_");
             }

--- a/src/NLog.StructuredLogging.Json/JsonWithPropertiesLayout.cs
+++ b/src/NLog.StructuredLogging.Json/JsonWithPropertiesLayout.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
 using NLog.Config;
 using NLog.Layouts;
 using NLog.StructuredLogging.Json.Helpers;
@@ -26,8 +28,12 @@ namespace NLog.StructuredLogging.Json
     ///   </target>
     /// </example>
     [Layout("jsonwithproperties")]
+    [ThreadSafe]
     public class JsonWithPropertiesLayout : Layout
     {
+        private JsonSerializer JsonSerializer => _jsonSerializer ?? (_jsonSerializer = ConvertJson.CreateJsonSerializer());
+        private JsonSerializer _jsonSerializer;
+
         [ArrayParameter(typeof(StructuredLoggingProperty), "property")]
         public IList<StructuredLoggingProperty> Properties { get; private set; }
 
@@ -40,14 +46,45 @@ namespace NLog.StructuredLogging.Json
 
         protected override string GetFormattedMessage(LogEventInfo logEvent)
         {
+            Dictionary<string, object> dictionary = BuildPropertiesDictionary(logEvent);
+            return ConvertJson.Serialize(dictionary);
+        }
+
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            var result = BuildPropertiesDictionary(logEvent);
+            var orgLength = target.Length;
+
+            try
+            {
+                // Ensure we are threadsafe
+                var jsonSerializer = JsonSerializer;
+                lock (jsonSerializer)
+                {
+                    // Serialize directly into StringBuilder
+                    ConvertJson.Serialize(result, target, jsonSerializer);
+                }
+            }
+            catch
+            {
+                _jsonSerializer = null; // Do not reuse JsonSerializer, as it might have become broken
+                target.Length = orgLength;  // Skip invalid JSON
+                throw;
+            }
+        }
+
+        private Dictionary<string, object> BuildPropertiesDictionary(LogEventInfo logEvent)
+        {
             var dictionary = Mapper.ToDictionary(logEvent);
 
-            foreach (var property in Properties)
+            // Enumerate without allocation of GetEnumerator()
+            for (int i = 0; i < Properties.Count; ++i)
             {
+                var property = Properties[i];
                 AddRenderedValue(logEvent, dictionary, property);
             }
 
-            return ConvertJson.Serialize(dictionary);
+            return dictionary;
         }
 
         private static void AddRenderedValue(

--- a/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
+++ b/src/NLog.StructuredLogging.Json/NLog.StructuredLogging.Json.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-     <PackageReference Include="NLog" Version="4.5.0" />
+     <PackageReference Include="NLog" Version="4.5.3" />
      <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.1" PrivateAssets="All" />

--- a/src/NLog.StructuredLogging.Json/StructuredLoggingLayoutRenderer.cs
+++ b/src/NLog.StructuredLogging.Json/StructuredLoggingLayoutRenderer.cs
@@ -1,17 +1,46 @@
-﻿using System.Text;
+using System.Text;
+using NLog.Config;
 using NLog.StructuredLogging.Json.Helpers;
 using NLog.LayoutRenderers;
+using Newtonsoft.Json;
 
 namespace NLog.StructuredLogging.Json
 {
     [LayoutRenderer("structuredlogging.json")]
+    [ThreadSafe]
     public class StructuredLoggingLayoutRenderer : LayoutRenderer
     {
+        private JsonSerializer JsonSerializer => _jsonSerializer ?? (_jsonSerializer = ConvertJson.CreateJsonSerializer());
+        private JsonSerializer _jsonSerializer;
+
         protected override void Append(StringBuilder builder, LogEventInfo logEvent)
         {
             var dictionary = Mapper.ToDictionary(logEvent);
-            var json = ConvertJson.Serialize(dictionary);
-            builder.Append(json);
+
+            var orgLength = builder.Length;
+
+            try
+            {
+                // Ensure we are threadsafe
+                var jsonSerializer = JsonSerializer;
+                lock (jsonSerializer)
+                {
+                    // Serialize directly into StringBuilder
+                    ConvertJson.Serialize(dictionary, builder, jsonSerializer);
+                }
+            }
+            catch
+            {
+                _jsonSerializer = null; // Do not reuse JsonSerializer, as it might have become broken
+                builder.Length = orgLength;  // Skip invalid JSON
+                throw;
+            }
+        }
+
+        protected override void CloseLayoutRenderer()
+        {
+            _jsonSerializer = null;
+            base.CloseLayoutRenderer();
         }
     }
 }


### PR DESCRIPTION
Reduced memory allocation by skipping string-allocation by writing directly to StringBuilder and reusing JsonSerializer. Improved concurrency by marking Layout as ThreadSafe.

Performance improved by 10 pct. Memory Allocation reduced by 30 pct.